### PR TITLE
Search page (1st iteration)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@peripleo/peripleo": "file:../peripleo",
         "d3-scale": "^4.0.2",
         "date-fns": "^2.29.3",
+        "diacritics": "^1.3.0",
+        "fuse.js": "^6.6.2",
         "ngraph.graph": "^20.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1241,6 +1243,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA=="
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2200,6 +2207,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {
@@ -5407,6 +5422,11 @@
         "object-keys": "^1.1.1"
       }
     },
+    "diacritics": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/diacritics/-/diacritics-1.3.0.tgz",
+      "integrity": "sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA=="
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -6030,6 +6050,11 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
+    },
+    "fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@peripleo/peripleo": "file:../peripleo",
     "d3-scale": "^4.0.2",
     "date-fns": "^2.29.3",
+    "diacritics": "^1.3.0",
+    "fuse.js": "^6.6.2",
     "ngraph.graph": "^20.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import { ErrorPage, HomePage, MapPage } from './pages';
+import { ErrorPage, HomePage, MapPage, SearchPage } from './pages';
 import { Root } from './Root';
 
 import './index.css';
@@ -31,6 +31,10 @@ const router = createBrowserRouter([
       {
         path: 'trajectories',
         element: <MapPage />,
+      },
+      {
+        path: 'search',
+        element: <SearchPage />,
       },
     ],
   },

--- a/src/pages/SearchPage/SearchPage.css
+++ b/src/pages/SearchPage/SearchPage.css
@@ -1,0 +1,35 @@
+#search input {
+  width: 100%;
+  height: 2.5em;
+  font-size: 1.25em;
+  padding: 0.3125em;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+#search-results ul {
+  padding: 30px 0;
+  margin: 0;
+  list-style-type: none;
+}
+
+.search-result h3 {
+  color: #406afc;
+  font-weight: normal;
+  margin: 0;
+  padding: 0 0 0.3em 0;
+}
+
+.search-result h4 {
+  margin: 0;
+  padding: 0 0 0.3em 0;
+  font-size: 0.9em;
+  color: #6A727C;
+  font-weight: normal;
+}
+
+.search-result p {
+  margin: 0;
+  padding: 0 0 2.2em 0;
+  font-size: 0.9em;
+}

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { useGraph } from '@peripleo/peripleo';
+import { useOutletContext } from 'react-router-dom';
+import { SearchResult } from './SearchResult';
+
+// Minimum input length (chars) to trigger search
+const MIN_LENGTH = 3;
+
+import './SearchPage.css';
+
+export function SearchPage() {
+  const { loaded } = useOutletContext();
+
+  const graph = useGraph();
+
+  const [results, setResults] = useState([]);
+
+  const onChange = (evt) => {
+    const { value } = evt.target;
+
+    if (value.length > MIN_LENGTH) {
+      const results = graph.search(value);
+
+      // Waypoints matched by this text search
+      const waypoints = results.filter((r) => r.type === 'waypoint');
+
+      // Matched authors -> resolve to all waypoints for this author
+      const authors = results.filter((r) => r['@type'] === 'Person');
+      const authorWaypoints = authors.reduce(
+        (wps, author) => [...wps, ...graph.getItineraryForAuthor(author.id)],
+        []
+      );
+
+      // Matched places --> resolve to all waypoints at this place
+      const places = results.filter((r) => r.type === 'Feature');
+      const placeWaypoints = places.reduce(
+        (wps, place) => [...wps, ...graph.getWaypointsAt(place.id)],
+        []
+      );
+
+      // Now merge (and de-duplicate) the results
+      const mergedWaypoints = [...waypoints, ...authorWaypoints, ...placeWaypoints].reduce(
+        (merged, nextWP) => {
+          const exists = merged.find((wp) => wp.id === nextWP.id);
+          return exists ? merged : [...merged, nextWP];
+        },
+        []
+      );
+
+      setResults(mergedWaypoints);
+    } else {
+      setResults([]);
+    }
+  };
+
+  return (
+    loaded && (
+      <main id="search">
+        <form action="#" name="search" onSubmit={(evt) => evt.preventDefault()}>
+          <input
+            type="text"
+            placeholder="Search authors, cities, notes and citations."
+            onChange={onChange}
+          />
+        </form>
+
+        <div id="search-results">
+          {results.length === 0 ? (
+            <p>Begin typing above.</p>
+          ) : (
+            <ul>
+              {results.map((result) => (
+                <li key={result.id}>
+                  <SearchResult data={result} graph={graph} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </main>
+    )
+  );
+}

--- a/src/pages/SearchPage/SearchResult.jsx
+++ b/src/pages/SearchPage/SearchResult.jsx
@@ -1,0 +1,15 @@
+export const SearchResult = (props) => {
+  const { data, graph } = props;
+
+  return (
+    <div className={data.type}>
+      {data.type === 'waypoint' && (
+        <div className="search-result">
+          <h3 className="title">{graph.getNode(data.author).name}</h3>
+          <h4 className="subhead">{data.title}</h4>
+          <p className="description">{data.relation.label}</p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/pages/SearchPage/index.js
+++ b/src/pages/SearchPage/index.js
@@ -1,0 +1,1 @@
+export * from './SearchPage';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,3 +1,4 @@
 export * from './ErrorPage';
 export * from './HomePage';
 export * from './MapPage';
+export * from './SearchPage';


### PR DESCRIPTION
## In this PR

- Per #10:
  - Adds fulltext indexing to the graph store, using [Fuse.js](https://fusejs.io/)
  - Includes diacritics filtering for search, using [diacritics](https://www.npmjs.com/package/diacritics)
  - Adds a handful of utility lookup methods to the graph, for retrieving waypoints visited by a given author, and waypoints located at a given place
  - Adds a search page, modeled on the example from [sameboats.org](http://sameboats.org/search/)
 
## Questions/Open Issues
- Search results waypoints __don't yet show a time interval.__ I think we need general utility functions for easy access to waypoint times, e.g. functions such as `getStart`, `getEnd`, `formatInterval` etc.
- Should search results get sorted by time? (In the original site, they are not.)