### PR TITLE
Validate date before changing filter state (#14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "ngraph.graph": "^20.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.6.0",
         "react-router-dom": "^6.4.2"
       },
       "devDependencies": {
@@ -3668,6 +3669,14 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -7051,6 +7060,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-icons": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.6.0.tgz",
+      "integrity": "sha512-rR/L9m9340yO8yv1QT1QurxWQvWpbNHqVX0fzMln2HEb9TEIrQRGsqiNFQfiv9/JEUbyHmHPlNTB2LWm2Ttz0g==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ngraph.graph": "^20.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.6.0",
     "react-router-dom": "^6.4.2"
   },
   "devDependencies": {

--- a/src/components/ITSBStore/itsbGraph.test.js
+++ b/src/components/ITSBStore/itsbGraph.test.js
@@ -35,14 +35,14 @@ describe('ITSBGraph', () => {
 
     const waypoints = graph.listItineraries()[3].waypoints;
 
-    // https://sameboats.org/authors/acesaire/itineraries/1/wp/27
+    // https://sameboats.org/authors/acesaire/itineraries/1/wp/26
     const a = waypoints[26];
 
     // https://sameboats.org/authors/acesaire/itineraries/1/wp/177
-    const b = waypoints[176]; // last in sequence
+    const b = waypoints[177]; // last in sequence
 
     const next = graph.getNextWaypoint(a);
-    expect(next.id).toBe('https://sameboats.org/authors/acesaire/itineraries/1/wp/28');
+    expect(next.id).toBe('https://sameboats.org/authors/acesaire/itineraries/1/wp/27');
 
     const undef = graph.getNextWaypoint(b);
     expect(undef).toBeUndefined();
@@ -53,13 +53,13 @@ describe('ITSBGraph', () => {
 
     const waypoints = graph.listItineraries()[3].waypoints;
 
-    // https://sameboats.org/authors/acesaire/itineraries/1/wp/27
+    // https://sameboats.org/authors/acesaire/itineraries/1/wp/26
     const a = waypoints[26];
 
     const b = graph.getNode('https://sameboats.org/authors/acesaire/itineraries/1/wp/0');
 
     const next = graph.getPreviousWaypoint(a);
-    expect(next.id).toBe('https://sameboats.org/authors/acesaire/itineraries/1/wp/26');
+    expect(next.id).toBe('https://sameboats.org/authors/acesaire/itineraries/1/wp/25');
 
     const undef = graph.getPreviousWaypoint(b);
     expect(undef).toBeUndefined();

--- a/src/components/ITSBStore/utils.js
+++ b/src/components/ITSBStore/utils.js
@@ -52,7 +52,7 @@ export const sortWaypoints = (waypoints, graph) => {
     return !previous || !ids.has(previous);
   });
 
-  const traverseItinerary = (waypoint, sorted = []) => {
+  const traverseItinerary = (waypoint, sorted = [waypoint]) => {
     let nextNode;
 
     graph.forEachLinkedNode(
@@ -63,7 +63,9 @@ export const sortWaypoints = (waypoints, graph) => {
       false
     );
 
-    return nextNode ? traverseItinerary(nextNode, [...sorted, nextNode]) : sorted;
+    return nextNode && ids.has(nextNode.id)
+      ? traverseItinerary(nextNode, [...sorted, nextNode])
+      : sorted;
   };
 
   return traverseItinerary(startPoint);

--- a/src/components/ITSBStore/utils.js
+++ b/src/components/ITSBStore/utils.js
@@ -63,12 +63,10 @@ export const sortWaypoints = (waypoints, graph) => {
       false
     );
 
-    return nextNode && ids.has(nextNode.id)
-      ? traverseItinerary(nextNode, [...sorted, nextNode])
-      : sorted;
+    return nextNode ? traverseItinerary(nextNode, [...sorted, nextNode]) : sorted;
   };
 
-  return traverseItinerary(startPoint);
+  return traverseItinerary(startPoint).filter((w) => ids.has(w.id));
 };
 
 /**

--- a/src/components/ITSBStore/utils.js
+++ b/src/components/ITSBStore/utils.js
@@ -80,17 +80,20 @@ export const groupBy = (xs, key) =>
     return rv;
   }, {});
 
-// check if a timespan (object with {start} or {end})
+// check if a timespan (object with {start} and/or {end})
 // is in a date range (array of Dates of length 2)
 export const timespanInRange = (timespan, dateRange) => {
   const [startDate, endDate] = dateRange;
-
-  if (timespan.start) {
+  if (timespan.start && timespan.end) {
+    const timespanStart = new Date(timespan.start.earliest || timespan.start.in);
+    const timespanEnd = new Date(timespan.end.latest || timespan.end.in);
+    return timespanStart >= new Date(startDate) && timespanEnd <= new Date(endDate);
+  } else if (timespan.start) {
     const date = new Date(timespan.start.earliest || timespan.start.in);
-    return date >= startDate && date <= endDate;
-  } else {
+    return date >= new Date(startDate) && date <= new Date(endDate);
+  } else if (timespan.end) {
     const date = new Date(timespan.end.latest || timespan.end.in);
-    return date >= startDate && date <= endDate;
+    return date >= new Date(startDate) && date <= new Date(endDate);
   }
 };
 

--- a/src/components/MonthRangeInput/MonthRangeInput.css
+++ b/src/components/MonthRangeInput/MonthRangeInput.css
@@ -1,0 +1,47 @@
+fieldset#month-range-input {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px 0 20px;
+  margin: 0 0 10px;
+  border: none;
+  border-bottom: 1px solid black;
+}
+fieldset#month-range-input button {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0 0;
+  overflow: visible;
+  text-transform: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  background: transparent;
+}
+fieldset#month-range-input button.down {
+  padding: 2px 0 0;
+}
+fieldset#month-range-input button.up {
+  padding: 0 0 2px;
+}
+
+div.button-container {
+  display: flex;
+  flex-flow: column;
+}
+input[type='month'] {
+  width: 120px;
+  text-align: center;
+  font-size: 0.75rem;
+  font-family: Courier, monospace;
+  height: 26px;
+  border: 1px solid gray;
+}
+input[type='month']:first-of-type {
+  margin: 0 5px 0 10px;
+}
+input[type='month']:last-of-type {
+  margin: 0 10px 0 5px;
+}

--- a/src/components/MonthRangeInput/MonthRangeInput.css
+++ b/src/components/MonthRangeInput/MonthRangeInput.css
@@ -11,6 +11,7 @@ fieldset#month-range-input {
 fieldset#month-range-input > div:first-child {
   display: flex;
   flex-flow: row nowrap;
+  align-items: center;
   margin: 0 0 10px;
 }
 fieldset#month-range-input span.error {

--- a/src/components/MonthRangeInput/MonthRangeInput.css
+++ b/src/components/MonthRangeInput/MonthRangeInput.css
@@ -1,11 +1,21 @@
 fieldset#month-range-input {
   display: flex;
+  flex-flow: column;
   align-items: center;
   justify-content: center;
-  padding: 5px 0 20px;
+  padding: 5px 0 10px;
   margin: 0 0 10px;
   border: none;
   border-bottom: 1px solid black;
+}
+fieldset#month-range-input > div:first-child {
+  display: flex;
+  flex-flow: row nowrap;
+  margin: 0 0 10px;
+}
+fieldset#month-range-input span.error {
+  color: red;
+  font-size: 0.9rem;
 }
 fieldset#month-range-input button {
   font-family: inherit;
@@ -19,6 +29,11 @@ fieldset#month-range-input button {
   padding: 0;
   display: flex;
   background: transparent;
+  pointer-events: all;
+}
+fieldset#month-range-input button:disabled {
+  cursor: default;
+  pointer-events: none;
 }
 fieldset#month-range-input button.down {
   padding: 2px 0 0;
@@ -44,4 +59,7 @@ input[type='month']:first-of-type {
 }
 input[type='month']:last-of-type {
   margin: 0 10px 0 5px;
+}
+input[type='month'].invalid {
+  border: 1px solid red;
 }

--- a/src/components/MonthRangeInput/MonthRangeInput.jsx
+++ b/src/components/MonthRangeInput/MonthRangeInput.jsx
@@ -34,6 +34,16 @@ export const MonthRangeInput = () => {
     setFilter({ name: 'daterange', range: updated });
   };
 
+  const onKeyDown = (date) => (evt) => {
+    if (evt.currentTarget.type === 'text') {
+      if (evt.key === 'ArrowUp') {
+        increment(date, 1)();
+      } else if (evt.key === 'ArrowDown') {
+        increment(date, -1)();
+      }
+    }
+  };
+
   return (
     <fieldset id="month-range-input">
       <div className="button-container">
@@ -53,6 +63,7 @@ export const MonthRangeInput = () => {
         max={fmt(maxDate)}
         value={fmt(from)}
         onChange={onChangeDate(from)}
+        onKeyDown={onKeyDown(from)}
       />
       &ndash;
       <input
@@ -63,6 +74,7 @@ export const MonthRangeInput = () => {
         max={fmt(maxDate)}
         value={fmt(to)}
         onChange={onChangeDate(to)}
+        onKeyDown={onKeyDown(to)}
       />
       <div className="button-container">
         <button className="up" name="end-up" onClick={increment(to, +1)}>

--- a/src/components/MonthRangeInput/MonthRangeInput.jsx
+++ b/src/components/MonthRangeInput/MonthRangeInput.jsx
@@ -1,5 +1,7 @@
-import { format, endOfToday, addMonths } from 'date-fns';
+import { addMonths, endOfMonth, endOfToday, format, startOfMonth } from 'date-fns';
+import { FaChevronUp, FaChevronDown } from 'react-icons/fa';
 import { useSearch } from '@peripleo/peripleo';
+import './MonthRangeInput.css';
 
 // Shorthand
 const fmt = (date) => format(date, 'yyyy-MM');
@@ -24,25 +26,25 @@ export const MonthRangeInput = () => {
 
   const onChangeDate = (date) => (evt) => {
     const { value } = evt.target;
-
     const updated =
       date === from
-        ? [new Date(`${value}-01T00:00:00`), to]
-        : [from, new Date(`${value}-01T00:00:00`)];
+        ? [startOfMonth(new Date(`${value}-02T00:00:00`)), to]
+        : [from, endOfMonth(new Date(`${value}-02T00:00:00`))];
 
     setFilter({ name: 'daterange', range: updated });
   };
 
   return (
-    <fieldset style={{ textAlign: 'center' }}>
-      <button name="start-up" onClick={increment(from, +1)}>
-        Up
-      </button>
+    <fieldset id="month-range-input">
+      <div className="button-container">
+        <button className="up" name="start-up" onClick={increment(from, +1)}>
+          <FaChevronUp />
+        </button>
 
-      <button name="start-down" onClick={increment(from, -1)}>
-        Down
-      </button>
-
+        <button className="down" name="start-down" onClick={increment(from, -1)}>
+          <FaChevronDown />
+        </button>
+      </div>
       <input
         type="month"
         id="start-date"
@@ -52,7 +54,7 @@ export const MonthRangeInput = () => {
         value={fmt(from)}
         onChange={onChangeDate(from)}
       />
-
+      &ndash;
       <input
         type="month"
         id="end-date"
@@ -62,14 +64,15 @@ export const MonthRangeInput = () => {
         value={fmt(to)}
         onChange={onChangeDate(to)}
       />
+      <div className="button-container">
+        <button className="up" name="end-up" onClick={increment(to, +1)}>
+          <FaChevronUp />
+        </button>
 
-      <button name="end-up" onClick={increment(to, +1)}>
-        Up
-      </button>
-
-      <button name="end-down" onClick={increment(to, -1)}>
-        Down
-      </button>
+        <button className="down" name="end-down" onClick={increment(to, -1)}>
+          <FaChevronDown />
+        </button>
+      </div>
     </fieldset>
   );
 };

--- a/src/components/MonthRangeInput/MonthRangeInput.jsx
+++ b/src/components/MonthRangeInput/MonthRangeInput.jsx
@@ -1,10 +1,15 @@
-import { addMonths, endOfMonth, endOfToday, format, startOfMonth } from 'date-fns';
+import { useState } from 'react';
+import { addMonths, endOfMonth, endOfToday, format, isMatch, startOfMonth } from 'date-fns';
 import { FaChevronUp, FaChevronDown } from 'react-icons/fa';
 import { useSearch } from '@peripleo/peripleo';
 import './MonthRangeInput.css';
 
 // Shorthand
-const fmt = (date) => format(date, 'yyyy-MM');
+const fmtString = 'yyyy-MM';
+const fmt = (date) => format(date, fmtString);
+const isValid = (date) => date.length === fmtString.length && isMatch(date, fmtString);
+const monthStart = (formattedDate) => startOfMonth(new Date(`${formattedDate}-02T00:00:00`));
+const monthEnd = (formattedDate) => endOfMonth(new Date(`${formattedDate}-02T00:00:00`));
 
 // TODO lookup min date from graph!
 const minDate = new Date(1850, 0, 1);
@@ -12,78 +17,139 @@ const maxDate = endOfToday();
 
 export const MonthRangeInput = () => {
   const { search, setFilter } = useSearch();
-
   const [from, to] = search.args.filters?.find((f) => f.name === 'daterange')?.range || [
     minDate,
     maxDate,
   ];
 
-  const increment = (date, inc) => () => {
-    const updated = date === from ? [addMonths(date, inc), to] : [from, addMonths(date, inc)];
+  const [monthInputValue, setMonthInputValue] = useState({
+    from: fmt(from),
+    to: fmt(to),
+  });
 
-    setFilter({ name: 'daterange', range: updated });
+  const increment = (inc) => (evt) => {
+    const { name } = evt.currentTarget;
+    if (name.startsWith('start')) {
+      setMonthInputValue((prevState) => {
+        const newFrom = addMonths(monthStart(prevState.from), inc);
+        setFilter({ name: 'daterange', range: [newFrom, to] });
+        return {
+          from: fmt(newFrom),
+          to: prevState.to,
+        };
+      });
+    } else if (name.startsWith('end')) {
+      setMonthInputValue((prevState) => {
+        const newTo = addMonths(monthEnd(prevState.to), inc);
+        setFilter({ name: 'daterange', range: [from, newTo] });
+        return {
+          from: prevState.from,
+          to: fmt(newTo),
+        };
+      });
+    }
   };
 
-  const onChangeDate = (date) => (evt) => {
-    const { value } = evt.target;
-    const updated =
-      date === from
-        ? [startOfMonth(new Date(`${value}-02T00:00:00`)), to]
-        : [from, endOfMonth(new Date(`${value}-02T00:00:00`))];
-
-    setFilter({ name: 'daterange', range: updated });
-  };
-
-  const onKeyDown = (date) => (evt) => {
+  const onKeyDown = (evt) => {
     if (evt.currentTarget.type === 'text') {
       if (evt.key === 'ArrowUp') {
-        increment(date, 1)();
+        increment(1)(evt);
       } else if (evt.key === 'ArrowDown') {
-        increment(date, -1)();
+        increment(-1)(evt);
+      }
+    }
+  };
+
+  const onChangeDate = (evt) => {
+    const { name, value } = evt.target;
+    if (name === 'start-date') {
+      setMonthInputValue((prevState) => ({
+        from: value,
+        to: prevState.to,
+      }));
+      if (isValid(value)) {
+        setFilter({ name: 'daterange', range: [monthStart(value), to] });
+      }
+    } else if (name === 'end-date') {
+      setMonthInputValue((prevState) => ({
+        from: prevState.from,
+        to: value,
+      }));
+      if (isValid(value)) {
+        setFilter({ name: 'daterange', range: [from, monthEnd(value)] });
       }
     }
   };
 
   return (
     <fieldset id="month-range-input">
-      <div className="button-container">
-        <button className="up" name="start-up" onClick={increment(from, +1)}>
-          <FaChevronUp />
-        </button>
+      <div>
+        <div className="button-container">
+          <button
+            className="up"
+            disabled={!isValid(monthInputValue.from)}
+            name="start-up"
+            onClick={increment(1)}
+          >
+            <FaChevronUp />
+          </button>
 
-        <button className="down" name="start-down" onClick={increment(from, -1)}>
-          <FaChevronDown />
-        </button>
+          <button
+            className="down"
+            disabled={!isValid(monthInputValue.from)}
+            name="start-down"
+            onClick={increment(-1)}
+          >
+            <FaChevronDown />
+          </button>
+        </div>
+        <input
+          type="month"
+          id="start-date"
+          name="start-date"
+          min={fmt(minDate)}
+          max={fmt(maxDate)}
+          value={monthInputValue.from}
+          onChange={onChangeDate}
+          onKeyDown={isValid(monthInputValue.from) ? onKeyDown : () => {}}
+          className={isValid(monthInputValue.from) ? '' : 'invalid'}
+        />
+        &ndash;
+        <input
+          type="month"
+          id="end-date"
+          name="end-date"
+          min={fmt(minDate)}
+          max={fmt(maxDate)}
+          value={monthInputValue.to}
+          onChange={onChangeDate}
+          onKeyDown={isValid(monthInputValue.to) ? onKeyDown : () => {}}
+          className={isValid(monthInputValue.to) ? '' : 'invalid'}
+        />
+        <div className="button-container">
+          <button
+            className="up"
+            disabled={!isValid(monthInputValue.to)}
+            name="end-up"
+            onClick={increment(1)}
+          >
+            <FaChevronUp />
+          </button>
+
+          <button
+            className="down"
+            disabled={!isValid(monthInputValue.to)}
+            name="end-down"
+            onClick={increment(-1)}
+          >
+            <FaChevronDown />
+          </button>
+        </div>
       </div>
-      <input
-        type="month"
-        id="start-date"
-        name="start-date"
-        min={fmt(minDate)}
-        max={fmt(maxDate)}
-        value={fmt(from)}
-        onChange={onChangeDate(from)}
-        onKeyDown={onKeyDown(from)}
-      />
-      &ndash;
-      <input
-        type="month"
-        id="end-date"
-        name="end-date"
-        min={fmt(minDate)}
-        max={fmt(maxDate)}
-        value={fmt(to)}
-        onChange={onChangeDate(to)}
-        onKeyDown={onKeyDown(to)}
-      />
-      <div className="button-container">
-        <button className="up" name="end-up" onClick={increment(to, +1)}>
-          <FaChevronUp />
-        </button>
-
-        <button className="down" name="end-down" onClick={increment(to, -1)}>
-          <FaChevronDown />
-        </button>
+      <div>
+        {(!isValid(monthInputValue.from) || !isValid(monthInputValue.to)) && (
+          <span className="error">Dates must be in the format YYYY-MM.</span>
+        )}
       </div>
     </fieldset>
   );

--- a/src/pages/MapPage/MapPage.css
+++ b/src/pages/MapPage/MapPage.css
@@ -1,5 +1,5 @@
 aside {
-  width: 300px;
+  width: 330px;
   padding: 20px 10px;
   background-color: var(--sidebar-bg);
   height: calc(100% - 64px - 40px);
@@ -10,5 +10,5 @@ main#map {
   top: 64px;
   right: 0;
   bottom: 0;
-  left: 320px;
+  left: 350px;
 }


### PR DESCRIPTION
## In this PR

- Per #14:
  - Style month range inputs
  - Allow cross-browser keyboard control (up/down arrow keys) of the month range inputs
  - Validate input before changing the filter state

## Questions

- Is my approach in 39c51832d5f424aca52412cc7672a05ed113d6c2 decent? It technically works, but it raises a warning about updating the state for one component (`AuthorSelect`) in a different component (`MonthRangeInput`) when you change the date filter. I also don't like having to synchronize the filter state manually with the input state, nor mixing the two as in [this line](https://github.com/performant-software/itsb/blob/39c51832d5f424aca52412cc7672a05ed113d6c2/src/components/MonthRangeInput/MonthRangeInput.jsx#L35), but I don't know how else to handle invalid input while still allowing users to type in the date manually in browsers that don't support the `month` input type.
  - In the prior implementation (i.e. current `main`), typing any invalid dates in the field on Firefox or Safari throws an error and breaks everything. The goal here is to allow users with those browsers to manually type in the date, which may result in temporarily invalid/incomplete dates, so we need to handle those somehow.
  - If you want to try playing around with other approaches, you can check out 9d46939d637ccc4074be8151f91b97afb156b914 and still get the benefit of the new styles and keyboard input handling.
- I noticed a strange bug that appears to be present in current `main` as well: changing the start date successfully updates the filter state and filters the results by date, but changing the end date does not. Any idea why?