### PR TITLE
Sorting of waypoints by time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
       "devDependencies": {
         "@types/chroma-js": "^2.1.4",
         "@types/react": "^18.0.21",
+        "@types/react-dom": "^18.0.8",
         "@vitejs/plugin-react": "^2.1.0",
         "vite": "^3.1.3"
       },
@@ -5139,6 +5140,7 @@
         "@turf/centroid": "^6.5.0",
         "@types/chroma-js": "^2.1.4",
         "@types/react": "^18.0.21",
+        "@types/react-dom": "^18.0.8",
         "@vitejs/plugin-react": "^2.1.0",
         "chroma-js": "^2.4.2",
         "fuse.js": "^6.6.2",

--- a/src/components/ITSBStore/itsbGraph.js
+++ b/src/components/ITSBStore/itsbGraph.js
@@ -1,7 +1,13 @@
 import createGraph from 'ngraph.graph';
 import Fuse from 'fuse.js';
 import diacritics from 'diacritics';
-import { normalizeNode, filterByTime, groupBy, sortWaypoints, splitItinerary } from './utils';
+import {
+  filterWaypointsByTime,
+  groupBy,
+  normalizeNode,
+  sortWaypointsBySequence,
+  splitItinerary,
+} from './utils';
 
 /**
  * A domain graph model for ITSB with the following
@@ -60,8 +66,8 @@ export class ITSBGraph {
 
     // Itineraries are split to waypoint nodes
     const waypointNodes = itineraries
-      .reduce((waypoints, it) => {
-        return [...waypoints, ...splitItinerary(it)];
+      .reduce((allWaypoints, it) => {
+        return [...allWaypoints, ...splitItinerary(it)];
       }, [])
       .filter((wp) => {
         const isValid = this.exists(wp.author, wp.place);
@@ -137,13 +143,13 @@ export class ITSBGraph {
   listItineraries = (dateRange) => {
     const allWaypoints = this.listNodesWithProperty('type', 'waypoint');
 
-    const filtered = dateRange ? filterByTime(allWaypoints, dateRange) : allWaypoints;
+    const filtered = dateRange ? filterWaypointsByTime(allWaypoints, dateRange) : allWaypoints;
 
     const groupedByAuthor = groupBy(filtered, 'author');
 
     return Object.entries(groupedByAuthor).map(([author, waypoints]) => ({
       author,
-      waypoints: sortWaypoints(waypoints, this.graph),
+      waypoints: sortWaypointsBySequence(waypoints, this.graph),
     }));
   };
 

--- a/src/components/ITSBStore/utils.js
+++ b/src/components/ITSBStore/utils.js
@@ -1,4 +1,6 @@
-/** Just makes sure there's an 'id' prop on the node **/
+/**
+ * Just makes sure there's an 'id' prop on the graph node.
+ */
 export const normalizeNode = (n) => {
   if (n.id) return n;
 
@@ -10,7 +12,21 @@ export const normalizeNode = (n) => {
   return n;
 };
 
-/** Convert one itinerary to n waypoint nodes **/
+/**
+ * Generic method to group an array of objects by key
+ *
+ * https://stackoverflow.com/questions/14446511/most-efficient-method-to-groupby-on-an-array-of-objects
+ */
+export const groupBy = (xs, key) =>
+  xs.reduce((rv, x) => {
+    (rv[x[key]] = rv[x[key]] || []).push(x);
+    return rv;
+  }, {});
+
+/**
+ * Split one itinerary to n waypoint nodes. The method
+ * also sorts waypoints by time, to ensure correct sequence.
+ */
 export const splitItinerary = (it) => {
   const itineraryId = it.id;
   const authorId = it.target[0].id;
@@ -19,19 +35,54 @@ export const splitItinerary = (it) => {
   // Work around a conceptual difference between LP and our
   // graph model: 'id' in LP refers to the place; but it
   // identifies the waypoint node itself in our graph!
-  return waypointList.map((value, idx) => ({
+  const waypoints = waypointList.map((value, idx) => ({
     ...value,
     author: authorId,
     place: value.id,
     type: 'waypoint',
     id: `${itineraryId}/wp/${idx}`,
   }));
+
+  return sortWaypointsByTime(waypoints);
+};
+
+/**
+ * The method sorts waypoints according to the time
+ * given in the `when` element.
+ *
+ * @param {*} waypoints
+ * @returns the waypoints, sorted by time
+ */
+export const sortWaypointsByTime = (waypoints) => {
+  const sorted = [...waypoints];
+
+  sorted.sort((a, b) => {
+    const [startA, endA] = getWaypointInterval(a);
+    const [startB, endB] = getWaypointInterval(b);
+
+    // May be overlapping, but A starts first and ends first
+    const isABeforeB = startA <= startB && endA <= endB;
+
+    // Same, but reversed A -> B
+    const isBBeforeA = startB <= startA && endB <= endA;
+
+    if (isABeforeB) {
+      return -1;
+    } else if (isBBeforeA) {
+      return 1;
+    } else {
+      // A inside B or vice versa - sort by whichever starts first
+      return startA <= startB ? -1 : 1;
+    }
+  });
+
+  return sorted;
 };
 
 /**
  * Sorts waypoints in sequence by traversing the graph.
  */
-export const sortWaypoints = (waypoints, graph) => {
+export const sortWaypointsBySequence = (waypoints, graph) => {
   const ids = new Set(waypoints.map((wp) => wp.id));
 
   // The start point is the WP with either no previous
@@ -70,19 +121,10 @@ export const sortWaypoints = (waypoints, graph) => {
 };
 
 /**
- * Generic method to group an array of objects by key
- *
- * https://stackoverflow.com/questions/14446511/most-efficient-method-to-groupby-on-an-array-of-objects
+ * Helper to check if a timespan (object with {start} and/or {end})
+ * is in a date range (array of Dates of length 2)
  */
-export const groupBy = (xs, key) =>
-  xs.reduce((rv, x) => {
-    (rv[x[key]] = rv[x[key]] || []).push(x);
-    return rv;
-  }, {});
-
-// check if a timespan (object with {start} and/or {end})
-// is in a date range (array of Dates of length 2)
-export const timespanInRange = (timespan, dateRange) => {
+export const isTimespanInRange = (timespan, dateRange) => {
   const [startDate, endDate] = dateRange;
   if (timespan.start && timespan.end) {
     const timespanStart = new Date(timespan.start.earliest || timespan.start.in);
@@ -97,8 +139,71 @@ export const timespanInRange = (timespan, dateRange) => {
   }
 };
 
-export const filterByTime = (waypoints, dateRange) => {
+/**
+ * Filters the list of waypoints by the given date range.
+ *
+ * @param {*} waypoints
+ * @param {*} dateRange
+ * @returns the list of waypoints in the given time interval
+ */
+export const filterWaypointsByTime = (waypoints, dateRange) => {
   return waypoints.filter((waypoint) =>
-    waypoint.when.timespans.map((t) => timespanInRange(t, dateRange)).every(Boolean)
+    waypoint.when.timespans.map((t) => isTimespanInRange(t, dateRange)).every(Boolean)
   ); // i.e. all timespans evaluate to true
+};
+
+/**
+ * Returns the start date of this waypoint. Note that this
+ * method will return null, if the waypoint has no start specified.
+ *
+ * @param {*} waypoint
+ * @returns the start date, if any
+ */
+export const getWaypointStart = (waypoint) => {
+  if (!waypoint.when?.timespans) return;
+
+  if (waypoint.when.timespans.length === 0) return;
+
+  const startSpan = waypoint.when.timespans.find((t) => t.start)?.start;
+  return startSpan && new Date(startSpan.in || startSpan.earliest || startSpan.latest);
+};
+
+/**
+ * Returns the end date of this waypoint. Note that this
+ * method will return null, if the waypoint has no end specified.
+ *
+ * @param {*} waypoint
+ * @returns the end date, if any
+ */
+export const getWaypointEnd = (waypoint) => {
+  if (!waypoint.when?.timespans) return;
+
+  if (waypoint.when.timespans.length === 0) return;
+
+  const endSpan = waypoint.when.timespans.find((t) => t.end)?.end;
+  return endSpan && new Date(endSpan.in || endSpan.latest || endSpan.earliest);
+};
+
+/**
+ * Helper function to get the start/end interval for the
+ * given waypoint. Note that this method will fill in blanks!
+ * E.g. if the waypoint has no end date, but a start date, the
+ * interval returned will be [ start, start ].
+ *
+ * The method will return null if the waypoint has neither
+ * start nor end.
+ *
+ * @param {*} waypoint
+ * @returns a valid start/end interval or null
+ */
+export const getWaypointInterval = (waypoint) => {
+  const start = getWaypointStart(waypoint);
+  const end = getWaypointEnd(waypoint);
+
+  if (start || end) {
+    return [
+      start || end, // Start date, but fallback to end if none
+      end || start, // End date, but fallback to start if none
+    ];
+  }
 };

--- a/src/components/ITSBStore/utils.js
+++ b/src/components/ITSBStore/utils.js
@@ -153,35 +153,61 @@ export const filterWaypointsByTime = (waypoints, dateRange) => {
 };
 
 /**
- * Returns the start date of this waypoint. Note that this
+ * Returns the start time of this waypoint. The method returns
+ * the verbatim string value from the waypoint object. Note that this
  * method will return null, if the waypoint has no start specified.
  *
  * @param {*} waypoint
  * @returns the start date, if any
  */
-export const getWaypointStart = (waypoint) => {
+export const getWaypointStartValue = (waypoint) => {
   if (!waypoint.when?.timespans) return;
 
   if (waypoint.when.timespans.length === 0) return;
 
   const startSpan = waypoint.when.timespans.find((t) => t.start)?.start;
-  return startSpan && new Date(startSpan.in || startSpan.earliest || startSpan.latest);
+  return startSpan ? startSpan.in || startSpan.earliest || startSpan.latest : null;
 };
 
 /**
- * Returns the end date of this waypoint. Note that this
+ * Returns the end time of this waypoint. The method returns
+ * the verbatim string value from the waypoint object. Note that this
  * method will return null, if the waypoint has no end specified.
  *
  * @param {*} waypoint
  * @returns the end date, if any
  */
-export const getWaypointEnd = (waypoint) => {
+export const getWaypointEndValue = (waypoint) => {
   if (!waypoint.when?.timespans) return;
 
   if (waypoint.when.timespans.length === 0) return;
 
   const endSpan = waypoint.when.timespans.find((t) => t.end)?.end;
-  return endSpan && new Date(endSpan.in || endSpan.latest || endSpan.earliest);
+  return endSpan ? endSpan.in || endSpan.latest || endSpan.earliest : null;
+};
+
+/**
+ * Returns the start of this waypoint as a Date object. Note that this
+ * method will return null, if the waypoint has no start specified.
+ *
+ * @param {*} waypoint
+ * @returns the start date, if any
+ */
+export const getWaypointStartDate = (waypoint) => {
+  const startVal = getWaypointStartValue(waypoint);
+  return startVal ? new Date(startVal) : null;
+};
+
+/**
+ * Returns the end date of this waypoint as a Date object. Note that this
+ * method will return null, if the waypoint has no end specified.
+ *
+ * @param {*} waypoint
+ * @returns the end date, if any
+ */
+export const getWaypointEndDate = (waypoint) => {
+  const endVal = getWaypointEndValue(waypoint);
+  return endVal ? new Date(endVal) : null;
 };
 
 /**
@@ -197,13 +223,31 @@ export const getWaypointEnd = (waypoint) => {
  * @returns a valid start/end interval or null
  */
 export const getWaypointInterval = (waypoint) => {
-  const start = getWaypointStart(waypoint);
-  const end = getWaypointEnd(waypoint);
+  const start = getWaypointStartDate(waypoint);
+  const end = getWaypointEndDate(waypoint);
 
   if (start || end) {
     return [
       start || end, // Start date, but fallback to end if none
       end || start, // End date, but fallback to start if none
     ];
+  }
+};
+
+/**
+ * Returns a formatted string representation of the time
+ * interval of this waypoint.
+ *
+ * @param {*} waypoint
+ * @returns formatted string representation
+ */
+export const formatInterval = (waypoint) => {
+  const startVal = getWaypointStartValue(waypoint);
+  const endVal = getWaypointEndValue(waypoint);
+
+  if (startVal && endVal) {
+    return `${startVal} – ${endVal}`;
+  } else if (startVal || endVal) {
+    return startVal || endVal;
   }
 };

--- a/src/components/IntersectionsLayer/timeinterval.js
+++ b/src/components/IntersectionsLayer/timeinterval.js
@@ -1,4 +1,5 @@
 import { isAfter } from 'date-fns';
+import { getWaypointEnd, getWaypointStart } from '../ITSBStore/utils';
 
 /**
  * Time interval inference for waypoints. See below for Alex Gil's original
@@ -32,8 +33,8 @@ export const getTimeInterval = (waypoint, graph) => {
 
   if (waypoint.when.timespans.length === 0) return;
 
-  const start = getStart(waypoint);
-  const end = getEnd(waypoint);
+  const start = getWaypointStart(waypoint);
+  const end = getWaypointEnd(waypoint);
 
   if (start && end) {
     if (isAfter(start, end)) {
@@ -46,36 +47,18 @@ export const getTimeInterval = (waypoint, graph) => {
   }
 };
 
-const getStart = (waypoint) => {
-  if (!waypoint.when?.timespans) return;
-
-  if (waypoint.when.timespans.length === 0) return;
-
-  const startSpan = waypoint.when.timespans.find((t) => t.start)?.start;
-  return startSpan && new Date(startSpan.in || startSpan.earliest || startSpan.latest);
-};
-
-const getEnd = (waypoint) => {
-  if (!waypoint.when?.timespans) return;
-
-  if (waypoint.when.timespans.length === 0) return;
-
-  const endSpan = waypoint.when.timespans.find((t) => t.end)?.end;
-  return endSpan && new Date(endSpan.in || endSpan.latest || endSpan.earliest);
-};
-
 const inferInterval = (waypoint, graph) => {
   // Since this fn is internal, and only called from getTimeInterval,
   // we already know that max ONE of these is true!
-  const thisStart = getStart(waypoint);
-  const thisEnd = getEnd(waypoint);
+  const thisStart = getWaypointStart(waypoint);
+  const thisEnd = getWaypointEnd(waypoint);
 
   if (thisStart) {
     // New York example: use next WP to infer time here
     const next = graph.getNextWaypoint(waypoint);
 
     if (next) {
-      const nextStart = getStart(next) || getEnd(next);
+      const nextStart = getWaypointStart(next) || getWaypointEnd(next);
       if (nextStart) {
         if (isAfter(thisStart, nextStart)) {
           console.warn('Invalid time interval', thisStart, 'to', nextStart);
@@ -88,8 +71,8 @@ const inferInterval = (waypoint, graph) => {
     const previous = graph.getPreviousWaypoint(waypoint);
 
     if (previous) {
-      const previousEnd = getEnd(previous);
-      const previousStart = getStart(previous);
+      const previousEnd = getWaypointEnd(previous);
+      const previousStart = getWaypointStart(previous);
 
       if (previousEnd) {
         if (isAfter(previousEnd, thisEnd)) {

--- a/src/components/IntersectionsLayer/timeinterval.js
+++ b/src/components/IntersectionsLayer/timeinterval.js
@@ -1,5 +1,5 @@
 import { isAfter } from 'date-fns';
-import { getWaypointEnd, getWaypointStart } from '../ITSBStore/utils';
+import { getWaypointEndDate, getWaypointStartDate } from '../ITSBStore/utils';
 
 /**
  * Time interval inference for waypoints. See below for Alex Gil's original
@@ -33,8 +33,8 @@ export const getTimeInterval = (waypoint, graph) => {
 
   if (waypoint.when.timespans.length === 0) return;
 
-  const start = getWaypointStart(waypoint);
-  const end = getWaypointEnd(waypoint);
+  const start = getWaypointStartDate(waypoint);
+  const end = getWaypointEndDate(waypoint);
 
   if (start && end) {
     if (isAfter(start, end)) {
@@ -50,15 +50,15 @@ export const getTimeInterval = (waypoint, graph) => {
 const inferInterval = (waypoint, graph) => {
   // Since this fn is internal, and only called from getTimeInterval,
   // we already know that max ONE of these is true!
-  const thisStart = getWaypointStart(waypoint);
-  const thisEnd = getWaypointEnd(waypoint);
+  const thisStart = getWaypointStartDate(waypoint);
+  const thisEnd = getWaypointEndDate(waypoint);
 
   if (thisStart) {
     // New York example: use next WP to infer time here
     const next = graph.getNextWaypoint(waypoint);
 
     if (next) {
-      const nextStart = getWaypointStart(next) || getWaypointEnd(next);
+      const nextStart = getWaypointStartDate(next) || getWaypointEndDate(next);
       if (nextStart) {
         if (isAfter(thisStart, nextStart)) {
           console.warn('Invalid time interval', thisStart, 'to', nextStart);
@@ -71,8 +71,8 @@ const inferInterval = (waypoint, graph) => {
     const previous = graph.getPreviousWaypoint(waypoint);
 
     if (previous) {
-      const previousEnd = getWaypointEnd(previous);
-      const previousStart = getWaypointStart(previous);
+      const previousEnd = getWaypointEndDate(previous);
+      const previousStart = getWaypointStartDate(previous);
 
       if (previousEnd) {
         if (isAfter(previousEnd, thisEnd)) {

--- a/src/pages/SearchPage/SearchResult.jsx
+++ b/src/pages/SearchPage/SearchResult.jsx
@@ -3,8 +3,6 @@ import { formatInterval } from '../../components/ITSBStore/utils';
 export const SearchResult = (props) => {
   const { data, graph } = props;
 
-  console.log(data);
-
   return (
     <div className={data.type}>
       {data.type === 'waypoint' && (

--- a/src/pages/SearchPage/SearchResult.jsx
+++ b/src/pages/SearchPage/SearchResult.jsx
@@ -1,12 +1,18 @@
+import { formatInterval } from '../../components/ITSBStore/utils';
+
 export const SearchResult = (props) => {
   const { data, graph } = props;
+
+  console.log(data);
 
   return (
     <div className={data.type}>
       {data.type === 'waypoint' && (
         <div className="search-result">
           <h3 className="title">{graph.getNode(data.author).name}</h3>
-          <h4 className="subhead">{data.title}</h4>
+          <h4 className="subhead">
+            {data.title} <span className="time">({formatInterval(data)})</span>
+          </h4>
           <p className="description">{data.relation.label}</p>
         </div>
       )}


### PR DESCRIPTION
## In this PR

- As per #26:
  - Introduces utility methods for sorting waypoints by time
  - Applies time sorting to author itineraries on import 
- As per #10 
  - Adds a method to get a formatted string representation for waypoint time interval
  - Displays the time interval in the search results