### PR TITLE
Various CSS and layout tweaks

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -2,7 +2,6 @@
 header nav {
   height: 100%;
 }
-
 header nav ul {
   display: flex;
   height: 100%;
@@ -31,12 +30,12 @@ header nav ul li a.active {
 
 /* home link */
 header nav ul li:first-child {
-  min-width: 350px;
   width: 350px;
 }
 header nav ul li a.home {
   background-color: var(--gold);
   color: var(--navbar-bg);
+  font-weight: 500;
 }
 header nav ul li a.home:hover {
   text-decoration: underline;
@@ -46,10 +45,10 @@ header nav ul li a.home::before {
   content: '';
   display: block;
   min-width: 24px;
-  width: 24px;
-  height: 24px;
+  width: 30px;
+  height: 30px;
   margin-right: 1rem;
   background: url('/img/itsb_icon.svg');
   background-repeat: no-repeat;
-  background-size: 24px 24px;
+  background-size: 30px 30px;
 }

--- a/src/components/MonthRangeInput/MonthRangeInput.css
+++ b/src/components/MonthRangeInput/MonthRangeInput.css
@@ -52,8 +52,10 @@ input[type='month'] {
   text-align: center;
   font-size: 0.75rem;
   font-family: Courier, monospace;
-  height: 26px;
+  line-height: 30px;
   border: 1px solid gray;
+  border-radius: 2px;
+  font-family: 'DM Sans', Arial, Helvetica, sans-serif;
 }
 input[type='month']:first-of-type {
   margin: 0 5px 0 10px;

--- a/src/index.css
+++ b/src/index.css
@@ -89,6 +89,13 @@ main#search > div {
 main:not(#map) > article p {
   padding: 1.2em 0;
 }
+main:not(#map) > article > p,
+main:not(#map) > article > section p {
+  max-width: 60ch;
+}
+main:not(#map) > article li {
+  max-width: 60ch;
+}
 
 main:not(#map) > article::after {
   content: '';

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,25 @@
   --sidebar-bg: #e4f3ff;
 }
 
+.btn {
+  align-items: center;
+  white-space: nowrap;
+  justify-content: center;
+  padding: 8px 20px;
+  margin-bottom: 1.5rem;
+  border-radius: 2px;
+  font-weight: 500;
+  text-decoration: none;
+  color: var(--navbar-link);
+  background-color: var(--navbar-bg);
+}
+
+.btn:hover,
+.btn:focus,
+.btn:active {
+  color: var(--gold);
+}
+
 html,
 body,
 #app {
@@ -30,12 +49,18 @@ body,
 }
 main:not(#map) {
   overflow-y: auto;
+  display: flex;
+  flex-direction: row;
   width: 100%;
+}
+main:not(#map) .flex-spacer {
+  width: 350px;
+  box-sizing: border-box;
 }
 main:not(#map) h1 {
   font-size: 2rem;
   margin-block-start: 1.5rem;
-  margin-block-end: 1.5rem;
+  margin-block-end: 1rem;
 }
 main:not(#map) h2 {
   font-size: 1.5rem;
@@ -45,20 +70,28 @@ main:not(#map) h2 {
 main:not(#map) h3 {
   font-size: 1.17rem;
 }
+main:not(#map) hr {
+  border-style: solid;
+  border-color: #525252;
+  border-width: 1px 0 0 0;
+  padding-bottom: 2em;
+}
+main:not(#map) section {
+  padding-bottom: 1.4em;
+}
 main:not(#map) > article,
 main#search > div {
-  padding: 30px 30px 30px 0;
-  width: 60ch;
-  max-width: 60ch;
-  margin: 0 0 0 350px;
-  line-height: 1.5;
-  overflow-y: auto;
+  padding: 30px 30px 80px 30px;
+  max-width: 980px;
+  line-height: 1.7;
 }
-/* center content layout on large displays */
-@media (min-width: 1660px) {
-  main:not(#map) > article,
-  main#search > div {
-    padding: 30px;
-    margin: 0 auto;
-  }
+
+main:not(#map) > article p {
+  padding: 1.2em 0;
+}
+
+main:not(#map) > article::after {
+  content: '';
+  display: block;
+  padding-bottom: 4em;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2,7 +2,7 @@
   --gold: #fcb040;
   --navbar-bg: black;
   --navbar-link: white;
-  --sidebar-bg: #e4f3ff;
+  --sidebar-bg: #f0f1f2;
 }
 
 .btn {

--- a/src/pages/CreditsPage/CreditsPage.jsx
+++ b/src/pages/CreditsPage/CreditsPage.jsx
@@ -8,6 +8,7 @@ import './CreditsPage.css';
 export function CreditsPage() {
   return (
     <main id="credits">
+      <div className="flex-spacer"></div>
       <article>
         <h1>Credits</h1>
         <section>

--- a/src/pages/HomePage/HomePage.css
+++ b/src/pages/HomePage/HomePage.css
@@ -1,36 +1,23 @@
 main#home aside {
   float: right;
   width: 30%;
-  max-width: 60ch;
-  margin-left: 3rem;
+  max-width: 235ch;
+  margin: 0.8rem 0 0 5rem;
 }
-main#home aside p {
-  font-size: 0.9rem;
+main#home aside section.vis-info {
+  margin-bottom: 3em;
+}
+main#home aside section.vis-info p {
+  font-size: 0.85rem;
+  padding: 1.2em 0 1.8em 0;
+}
+main#home aside h2 {
+  font-size: 1.2rem;
+  margin-bottom: 0;
 }
 main#home aside h2:first-child {
   margin-top: 0;
 }
-main#home aside a {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 10px;
-  margin-bottom: 1.5rem;
-  border-radius: 20px;
-  font-weight: bold;
-  text-decoration: none;
-  color: var(--navbar-link);
-  background-color: var(--navbar-bg);
-}
-main#home aside a:hover,
-main#home aside a:focus,
-main#home aside a:active {
-  color: var(--gold);
-}
-main#home aside a::after {
-  content: '\2192';
-  margin-left: 5px;
-}
-main#home a {
-  color: var(--navbar-bg);
+main#home aside p {
+  margin: 0;
 }

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -9,25 +9,35 @@ import './HomePage.css';
 export function HomePage() {
   return (
     <main id="home">
+      <div className="flex-spacer"></div>
       <article>
         <h1>Welcome</h1>
         <aside>
-          <h2>Trajectories</h2>
-          <p>
-            This visualization presents an interactive narrative overview of one or more
-            individuals&apos; movements through space over time. The timeline function allows for
-            the researcher to consider specific periods or phases, individually or in comparison
-            with other figures.
-          </p>
-          <Link to="/trajectories">View trajectories</Link>
-          <h2>Intersections</h2>
-          <p>
-            This visualization presents an interactive snapshot overview of the world map that
-            reflects the presence of Afro-Atlantic figures in particular geographical locations at
-            particular points in time. Clicking on a given city which figures were present in that
-            place and when they were there.
-          </p>
-          <Link to="/intersections">View intersections</Link>
+          <section className="vis-info">
+            <h2>Trajectories</h2>
+            <p>
+              This visualization presents an interactive narrative overview of one or more
+              individuals&apos; movements through space over time. The timeline function allows for
+              the researcher to consider specific periods or phases, individually or in comparison
+              with other figures.
+            </p>
+            <Link className="btn" to="/trajectories">
+              View trajectories
+            </Link>
+          </section>
+
+          <section className="vis-info">
+            <h2>Intersections</h2>
+            <p>
+              This visualization presents an interactive snapshot overview of the world map that
+              reflects the presence of Afro-Atlantic figures in particular geographical locations at
+              particular points in time. Clicking on a given city which figures were present in that
+              place and when they were there.
+            </p>
+            <Link className="btn" to="/intersections">
+              View intersections
+            </Link>
+          </section>
         </aside>
         <p>
           <strong>In the Same Boats</strong> is a work of multimodal scholarship designed to
@@ -78,7 +88,9 @@ export function HomePage() {
           constitution of a 20th century Afro-Atlantic Republic of Arts and Letters.
         </p>
         <p>
-          <Link to="instructions">Learn how it works…</Link>
+          <Link className="btn" to="instructions">
+            Learn how it works…
+          </Link>
         </p>
       </article>
     </main>

--- a/src/pages/InstructionsPage/InstructionsPage.css
+++ b/src/pages/InstructionsPage/InstructionsPage.css
@@ -1,0 +1,3 @@
+main#instructions section {
+  max-width: 60ch;
+}

--- a/src/pages/InstructionsPage/InstructionsPage.jsx
+++ b/src/pages/InstructionsPage/InstructionsPage.jsx
@@ -6,62 +6,75 @@
 export function InstructionsPage() {
   return (
     <main id="instructions">
+      <div className="flex-spacer"></div>
       <article>
         <h1>Instructions</h1>
-        <h2>Trajectories</h2>
-        <p>
-          This visualization presents an interactive narrative overview of one or more individuals’
-          movements through space over time. The date range filter allows for the researcher to
-          consider specific periods or phases. You can select figures individually or you can
-          compare them to others by selecting them.
-        </p>
-        <ol>
-          <li>
-            Select a range of time using the date range filter in the left column. You can click the
-            up and down buttons to adjust the start and end date by month. You can also adjust the
-            months by clicking on the text box containing each date and either typing the month and
-            year, or using the up and down arrow keys on your keyboard. On certain browsers (Chrome,
-            Edge) you may be able to click a calendar icon to choose each month and year on a
-            calendar.
-          </li>
-          <li>Select one or more authors from the list in the left column.</li>
-          <li>
-            Once the map has been drawn, you can hover over any dot on the map to read a pop-up note
-            about that particular moment in time for that particular author.
-          </li>
-        </ol>
-        <h2>Intersections</h2>
-        <p>
-          This visualization presents an interactive snapshot overview of the world map that
-          reflects the presence of Afro-Atlantic figures in particular geographical locations at
-          particular points in time. Clicking on a given city reveals which figures were present in
-          that place and when they were there. We have worked to preserve a sense of ambiguity when
-          a range of time is not certain. This uncertainty is indicated via the transparent aura
-          encircling each dot. The size of the aura indicates the level of ambiguity.
-        </p>
-        <ol>
-          <li>Select a range of time by clicking on the date range in the left column.</li>
-          <li>Select one or more authors from the list in the left column.</li>
-          <li>
-            Select a dot on the map to see what figures were at that spot in the same time range.
-          </li>
-        </ol>
-        <h2>Search</h2>
-        <p>
-          In our search page you can search for authors, dates, keywords and more. Simply type in
-          your search terms in the search box to see the results.
-        </p>
+        <section>
+          <h2>Trajectories</h2>
+          <p>
+            This visualization presents an interactive narrative overview of one or more
+            individuals’ movements through space over time. The date range filter allows for the
+            researcher to consider specific periods or phases. You can select figures individually
+            or you can compare them to others by selecting them.
+          </p>
+          <ol>
+            <li>
+              Select a range of time using the date range filter in the left column. You can click
+              the up and down buttons to adjust the start and end date by month. You can also adjust
+              the months by clicking on the text box containing each date and either typing the
+              month and year, or using the up and down arrow keys on your keyboard. On certain
+              browsers (Chrome, Edge) you may be able to click a calendar icon to choose each month
+              and year on a calendar.
+            </li>
+            <li>Select one or more authors from the list in the left column.</li>
+            <li>
+              Once the map has been drawn, you can hover over any dot on the map to read a pop-up
+              note about that particular moment in time for that particular author.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h2>Intersections</h2>
+          <p>
+            This visualization presents an interactive snapshot overview of the world map that
+            reflects the presence of Afro-Atlantic figures in particular geographical locations at
+            particular points in time. Clicking on a given city reveals which figures were present
+            in that place and when they were there. We have worked to preserve a sense of ambiguity
+            when a range of time is not certain. This uncertainty is indicated via the transparent
+            aura encircling each dot. The size of the aura indicates the level of ambiguity.
+          </p>
+          <ol>
+            <li>Select a range of time by clicking on the date range in the left column.</li>
+            <li>Select one or more authors from the list in the left column.</li>
+            <li>
+              Select a dot on the map to see what figures were at that spot in the same time range.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h2>Search</h2>
+          <p>
+            In our search page you can search for authors, dates, keywords and more. Simply type in
+            your search terms in the search box to see the results.
+          </p>
+        </section>
+
         <hr />
-        <h2>Get on the Map</h2>
-        <p>
-          Same Boats is a fundamentally collaborative venture&mdash;an invitation of sorts meant to
-          provide our community with the opportunity to participate in the development of a unique
-          platform and to imagine research projects and pedagogical initiatives that transgress the
-          geo-political borders separating the various nations of the Americas. If you’re interested
-          in being a part of this project by proposing an additional figure or in working with one
-          of our existing figures/editors, please contact us at{' '}
-          <a href="mailto:thesameboats@gmail.com">thesameboats@gmail.com</a>.
-        </p>
+
+        <section>
+          <h2>Get on the Map</h2>
+          <p>
+            Same Boats is a fundamentally collaborative venture&mdash;an invitation of sorts meant
+            to provide our community with the opportunity to participate in the development of a
+            unique platform and to imagine research projects and pedagogical initiatives that
+            transgress the geo-political borders separating the various nations of the Americas. If
+            you’re interested in being a part of this project by proposing an additional figure or
+            in working with one of our existing figures/editors, please contact us at{' '}
+            <a href="mailto:thesameboats@gmail.com">thesameboats@gmail.com</a>.
+          </p>
+        </section>
       </article>
     </main>
   );

--- a/src/pages/InstructionsPage/InstructionsPage.jsx
+++ b/src/pages/InstructionsPage/InstructionsPage.jsx
@@ -1,3 +1,5 @@
+import './InstructionsPage.css';
+
 /**
  * Instructions page for ITSB (static content)
  *

--- a/src/pages/MapPage/MapPage.css
+++ b/src/pages/MapPage/MapPage.css
@@ -14,3 +14,11 @@ aside#intersection-details {
   background-color: #fff;
   overflow-y: scroll;
 }
+
+aside#intersection-details h1 {
+  font-weight: 500;
+}
+
+aside#intersection-details p {
+  line-height: 1.6;
+}

--- a/src/pages/SearchPage/SearchPage.css
+++ b/src/pages/SearchPage/SearchPage.css
@@ -15,7 +15,7 @@
   box-sizing: border-box;
 }
 #search section form {
-  max-width: 90%;
+  max-width: 60ch;
 }
 #search-results ul {
   padding: 30px 0;
@@ -42,4 +42,5 @@
   margin: 0;
   padding: 0 0 2.2em 0;
   font-size: 0.9em;
+  max-width: 60ch;
 }

--- a/src/pages/SearchPage/SearchPage.css
+++ b/src/pages/SearchPage/SearchPage.css
@@ -6,7 +6,17 @@
   -webkit-box-sizing: border-box;
   box-sizing: border-box;
 }
-
+#search .flex-spacer {
+  flex-shrink: 16;
+}
+#search section {
+  padding: 60px 10px;
+  width: 980px;
+  box-sizing: border-box;
+}
+#search section form {
+  max-width: 90%;
+}
 #search-results ul {
   padding: 30px 0;
   margin: 0;

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -61,7 +61,8 @@ export function SearchPage() {
   return (
     loaded && (
       <main id="search">
-        <div>
+        <div className="flex-spacer"></div>
+        <section className="search-wrapper">
           <form action="#" name="search" onSubmit={(evt) => evt.preventDefault()}>
             <input
               type="text"
@@ -83,7 +84,7 @@ export function SearchPage() {
               </ul>
             )}
           </div>
-        </div>
+        </section>
       </main>
     )
   );


### PR DESCRIPTION
This PR makes a few cosmetic changes to the different areas of the UI. __Suggestions only! Feel free to ignore/tweak them in any way.__
 
## In this PR
- Header
  - Logo slightly bigger + mid-bold font
- Text page layout (Home, Instructions) 
  - Adds padding to the article areas, so that text is aligned With the header menu __text__, not the header directly
  - Adds a bit more whitespace, line height and bottom padding to the text pages
  - Responsive layout: the 350px margin for text now collapses when page gets narrow
  - Suggestion: left-aligned buttons with hard corners instead of rounded (feel free to revert!)
- More responsive layout for Search Page
