### PR TITLE
Minor fix: waypoints now sorted by time in intersections sidebar

### DIFF
--- a/src/components/IntersectionDetails/IntersectionDetails.jsx
+++ b/src/components/IntersectionDetails/IntersectionDetails.jsx
@@ -1,5 +1,9 @@
 import { useGraph, useSearch } from '@peripleo/peripleo';
-import { estimateInterval, formatInterval } from '../../components/ITSBStore/utils';
+import {
+  estimateInterval,
+  formatInterval,
+  sortWaypointsByTime,
+} from '../../components/ITSBStore/utils';
 
 import './IntersectionDetails.css';
 
@@ -19,6 +23,8 @@ export const IntersectionDetails = (props) => {
     return [...all, ...waypoints.filter((wp) => wp.place === at.id)];
   }, []);
 
+  const sorted = waypointsAtThisPlace && sortWaypointsByTime(waypointsAtThisPlace);
+
   const getLikelihood = (waypoint) => estimateInterval(waypoint, graph)?.likelihood;
 
   return (
@@ -27,7 +33,7 @@ export const IntersectionDetails = (props) => {
         <>
           <h1>{at.properties.title}</h1>
           <ul>
-            {waypointsAtThisPlace.map((wp) => (
+            {sorted.map((wp) => (
               <li key={wp.id} className={`likelihood-${getLikelihood(wp)}`}>
                 <span className="wp-author">{graph.getNode(wp.author).name}</span>{' '}
                 <span className="wp-interval">{formatInterval(wp)}</span>


### PR DESCRIPTION
## In this PR:
- Just a tiny fix that sorts waypoints by time in the details sidebar of the Intersections page. (Same behavior as original app.)