### PR TITLE
Fix: overlays no longer lose sync with basemap on resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@peripleo/peripleo": "0.1.10",
+        "@peripleo/peripleo": "0.1.11",
         "d3-scale": "^4.0.2",
         "date-fns": "^2.29.3",
         "diacritics": "^1.3.0",
@@ -940,9 +940,9 @@
       }
     },
     "node_modules/@peripleo/peripleo": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@peripleo/peripleo/-/peripleo-0.1.10.tgz",
-      "integrity": "sha512-iM1Se8LPwO2f1Epz6Z3MMTcQJzqStGfgnkL942fmEziFF1PI9y2ngln+dPLHwt9qzbAs1GbuYlmZPAMEntRvWw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@peripleo/peripleo/-/peripleo-0.1.11.tgz",
+      "integrity": "sha512-VfBcYiO6LoUSwiVZisJ8qEenQYzAtO1DTRmg29rqUhAOvX1zAKlUO7ZgvbMMMrpqplFLNLxEQWIoOEqMlq3AFw==",
       "dependencies": {
         "@deck.gl/core": "8.8.16",
         "@deck.gl/layers": "8.8.16",
@@ -6396,9 +6396,9 @@
       }
     },
     "@peripleo/peripleo": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@peripleo/peripleo/-/peripleo-0.1.10.tgz",
-      "integrity": "sha512-iM1Se8LPwO2f1Epz6Z3MMTcQJzqStGfgnkL942fmEziFF1PI9y2ngln+dPLHwt9qzbAs1GbuYlmZPAMEntRvWw==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@peripleo/peripleo/-/peripleo-0.1.11.tgz",
+      "integrity": "sha512-VfBcYiO6LoUSwiVZisJ8qEenQYzAtO1DTRmg29rqUhAOvX1zAKlUO7ZgvbMMMrpqplFLNLxEQWIoOEqMlq3AFw==",
       "requires": {
         "@deck.gl/core": "8.8.16",
         "@deck.gl/layers": "8.8.16",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@peripleo/peripleo": "0.1.10",
+    "@peripleo/peripleo": "0.1.11",
     "d3-scale": "^4.0.2",
     "date-fns": "^2.29.3",
     "diacritics": "^1.3.0",

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -39,6 +39,7 @@ export function MapPage() {
 
         <main id="map">
           <Map.MapLibreDeckGL
+            key={isTrajectories ? 'trajectories' : 'intersections'}
             mapStyle="https://api.maptiler.com/maps/outdoor/style.json?key=cqqmcLw28krG9Fl7V3kg"
             defaultBounds={[
               // [[minLon, minLat], [maxLon, maxLat]

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,6 +12,9 @@ export default defineConfig({
       'mapbox-gl': 'maplibre-gl',
     },
   },
+  // optimizeDeps: {
+  //   exclude: ['@peripleo/peripleo']
+  // },
   server: {
     open: '/',
   },


### PR DESCRIPTION
## In this PR

This PR fixes issue #38: map overlays lost sync with the basemap when resizing the browser window. 

Some context: We have actually introduced this problem ourselves. DeckGL __normally__ handles resizing and syncing between overlays and map just fine. However, we had an issue when switching between `/trajectories` and `/intersections` pages. Because the map has different size in those pages, toggling between them caused an offset between overlays and map. (It looked like the DeckGL overlays would handle the page transition fine, and resize correctly, but the basemap remained stuck, causing an offset. See discussion here #29)

As a workaround I introduced a hack that listens to resize events on the map container and than forces a viewport reset on the map. This fixed the problem for the resize that happens as part of the page transition. However, as seen in #38, normal resize no longer works properly. TBH I don't have a real explanation why - except that I'm probably misunderstanding how the map viewport management works in DeckGL, and that we should better not interfere with it ;-) 

Anyways: here's a new solution that's probably much cleaner than the original.
1. We no longer mess with DeckGL viewport management.
2. Instead, we force a complete re-init of the map component __only__ for the page change. Technically, this means it's no longer a resize, but a full component re-render.

### The Fix

- I removed our viewport management hack from the `@peripleo/peripleo` npm package, and published a new version (0.1.11)
- I added a `key` property to the `<Map.MapLibreDeckGL>` component which is either `trajectories` or `intersections` based on which page we're on. (Changing the key prop [forces a full re-render](https://medium.com/@albertogasparin/forcing-state-reset-on-a-react-component-by-using-the-key-prop-14b36cd7448e).)

As an added bonus, I made a tweak to `@peripleo\peripleo` to take into account the global Recoil state for the initial map position. This means: although we're now re-creating the map when changing pages, the map center + zoom remain persistent, just as before.