### PR TITLE
Use HashRouter instead of BrowserRouter (#40)

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createHashRouter, RouterProvider } from 'react-router-dom';
 import { CreditsPage, ErrorPage, HomePage, InstructionsPage, MapPage, SearchPage } from './pages';
 import { Root } from './Root';
 
@@ -15,7 +15,7 @@ const fetchMapData = async () =>
     fetchData('data/itineraries.json'),
   ]);
 
-const router = createBrowserRouter(
+const router = createHashRouter(
   [
     {
       element: <Root />,


### PR DESCRIPTION
## In this PR

- Per #40:
  - Use `createHashRouter` to allow navigating directly to URLs in a GH Pages deployment