### PR TITLE
Adapt layout for mobile (#48)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,15 @@
 <!doctype html>
 <html lang="en">
 
-    <head>
-        <meta charset="utf-8" />
-        <title>In the Same Boats</title>
-    </head>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>In the Same Boats</title>
+</head>
 
-    <body>
-        <div id="app"></div>
-        <script type="module" src="./src/index.jsx"></script>
-    </body>
+<body>
+    <div id="app"></div>
+    <script type="module" src="./src/index.jsx"></script>
+</body>
 
 </html>

--- a/src/components/AuthorSelect/AuthorSelect.css
+++ b/src/components/AuthorSelect/AuthorSelect.css
@@ -2,7 +2,9 @@ ul.author-select {
   list-style-type: none;
   padding: 0;
   margin: 0;
-  font-size: 17px; 
+  font-size: 0.75rem;
+  display: flex;
+  flex-flow: row wrap;
 }
 
 ul.author-select li {
@@ -13,4 +15,12 @@ ul.author-select li {
 ul.author-select li label {
   cursor: pointer;
   padding-left: 5px;
-} 
+}
+
+/* medium-sized displays and larger */
+@media (min-width: 640px) {
+  ul.author-select {
+    font-size: 17px;
+    display: block;
+  }
+}

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -96,6 +96,7 @@ header nav ul li a.active {
   color: var(--gold);
 }
 
+/* medium-sized displays and larger */
 @media (min-width: 640px) {
   header nav {
     flex-flow: row nowrap;

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,14 +1,82 @@
-/* header nav list */
+/* header nav */
 header nav {
   height: 100%;
-}
-header nav ul {
   display: flex;
+  flex-flow: row wrap;
+}
+/* home link */
+header nav div.home {
+  display: flex;
+  flex: 0 1 calc(100% - 64px);
+}
+header nav div.home a {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--gold);
+  color: var(--navbar-bg);
+  font-weight: 500;
+  text-decoration: none;
+  width: 100%;
   height: 100%;
+  padding: 0 30px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+header nav div.home a:hover {
+  text-decoration: underline;
+}
+/* home icon */
+header nav div.home a::before {
+  content: '';
+  display: block;
+  min-width: 24px;
+  width: 30px;
+  height: 30px;
+  margin-right: 1rem;
+  background: url('/img/itsb_icon.svg');
+  background-repeat: no-repeat;
+  background-size: 30px 30px;
+}
+/* mobile nav toggle */
+label[for='mobile-nav-toggle'] {
+  cursor: pointer;
+  display: flex;
+  width: 64px;
+  height: 64px;
+  overflow: visible;
+  font-size: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--navbar-bg);
+}
+label[for='mobile-nav-toggle'] svg {
+  width: 32px;
+  height: 32px;
+  fill: var(--navbar-link);
+}
+input#mobile-nav-toggle {
+  display: none;
+}
+header nav input#mobile-nav-toggle {
+  display: none;
+}
+/* nav link list */
+header nav ul {
+  display: none;
+  flex-basis: 100%;
   list-style: none;
   background-color: var(--navbar-bg);
   margin: 0;
   padding: 0;
+}
+header nav input#mobile-nav-toggle:checked ~ ul {
+  display: flex;
+  flex-flow: column;
+}
+header nav ul li {
+  min-height: 48px;
 }
 header nav ul li a {
   display: flex;
@@ -28,27 +96,21 @@ header nav ul li a.active {
   color: var(--gold);
 }
 
-/* home link */
-header nav ul li:first-child {
-  width: 350px;
-}
-header nav ul li a.home {
-  background-color: var(--gold);
-  color: var(--navbar-bg);
-  font-weight: 500;
-}
-header nav ul li a.home:hover {
-  text-decoration: underline;
-}
-/* home icon */
-header nav ul li a.home::before {
-  content: '';
-  display: block;
-  min-width: 24px;
-  width: 30px;
-  height: 30px;
-  margin-right: 1rem;
-  background: url('/img/itsb_icon.svg');
-  background-repeat: no-repeat;
-  background-size: 30px 30px;
+@media (min-width: 640px) {
+  header nav {
+    flex-flow: row nowrap;
+  }
+  header nav div.home {
+    width: 350px;
+    flex: 1 0 350px;
+    font-size: 1rem;
+  }
+  label[for='mobile-nav-toggle'] {
+    display: none;
+  }
+  header nav ul {
+    display: flex;
+    flex-flow: row;
+    height: 100%;
+  }
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,16 +1,27 @@
 import { Link, NavLink } from 'react-router-dom';
 import './Header.css';
 
+/**
+ * Header component, containing navigation links to pages in the application.
+ *
+ * @returns {React.Component} Header React functional component
+ */
 export function Header() {
   return (
     <header>
       <nav>
+        <div className="home">
+          <Link to="/">
+            <span>In The Same Boats</span>
+          </Link>
+        </div>
+        <input id="mobile-nav-toggle" name="mobile-nav-toggle" type="checkbox" />
+        <label htmlFor="mobile-nav-toggle">
+          <svg focusable="false" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
+          </svg>
+        </label>
         <ul>
-          <li>
-            <Link to="/" className="home">
-              <span>In The Same Boats</span>
-            </Link>
-          </li>
           <li>
             <NavLink to="instructions">Instructions</NavLink>
           </li>

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -5,7 +5,7 @@ import './Header.css';
 /**
  * Header component, containing navigation links to pages in the application.
  *
- * @returns {React.Component} Header React functional component
+ * @returns {ReactElement} Header React functional component
  */
 export function Header() {
   // hide mobile menu after navigating

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,4 +1,5 @@
-import { Link, NavLink } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 import './Header.css';
 
 /**
@@ -7,6 +8,13 @@ import './Header.css';
  * @returns {React.Component} Header React functional component
  */
 export function Header() {
+  // hide mobile menu after navigating
+  const location = useLocation();
+  const [mobileMenuVisible, setMobileMenuVisible] = useState(false);
+  useEffect(() => {
+    setMobileMenuVisible(false);
+  }, [location]);
+
   return (
     <header>
       <nav>
@@ -15,7 +23,15 @@ export function Header() {
             <span>In The Same Boats</span>
           </Link>
         </div>
-        <input id="mobile-nav-toggle" name="mobile-nav-toggle" type="checkbox" />
+        <input
+          id="mobile-nav-toggle"
+          name="mobile-nav-toggle"
+          type="checkbox"
+          checked={mobileMenuVisible}
+          onChange={() => {
+            setMobileMenuVisible((prevState) => !prevState);
+          }}
+        />
         <label htmlFor="mobile-nav-toggle">
           <svg focusable="false" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>

--- a/src/components/MonthRangeInput/MonthRangeInput.css
+++ b/src/components/MonthRangeInput/MonthRangeInput.css
@@ -3,8 +3,8 @@ fieldset#month-range-input {
   flex-flow: column;
   align-items: center;
   justify-content: center;
-  padding: 5px 0 10px;
-  margin: 0 0 10px;
+  padding: 0;
+  margin: 0 0 5px;
   border: none;
   border-bottom: 1px solid black;
 }
@@ -65,4 +65,12 @@ input[type='month']:last-of-type {
 }
 input[type='month'].invalid {
   border: 1px solid red;
+}
+
+/* medium-sized displays and larger */
+@media (min-width: 640px) {
+  fieldset#month-range-input {
+    padding: 5px 0 10px;
+    margin: 0 0 10px;
+  }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,7 @@ body,
   flex-grow: 1;
   position: relative;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   max-height: calc(100vh - 64px);
 }
 main:not(#map) {
@@ -105,6 +105,9 @@ main:not(#map) > article::after {
 
 /* medium-sized displays and larger */
 @media (min-width: 640px) {
+  #app > section#content-wrapper {
+    flex-direction: row;
+  }
   main:not(#map) > article,
   main#search > div {
     padding: 30px 30px 80px 30px;

--- a/src/index.css
+++ b/src/index.css
@@ -60,12 +60,12 @@ main:not(#map) .flex-spacer {
 main:not(#map) h1 {
   font-size: 2rem;
   margin-block-start: 1.5rem;
-  margin-block-end: 1rem;
+  margin-block-end: 0.5rem;
 }
 main:not(#map) h2 {
   font-size: 1.5rem;
-  margin-block-start: 0.83rem;
-  margin-block-end: 0.83rem;
+  margin-block-start: 0.5rem;
+  margin-block-end: 0.5rem;
 }
 main:not(#map) h3 {
   font-size: 1.17rem;
@@ -77,7 +77,7 @@ main:not(#map) hr {
   padding-bottom: 2em;
 }
 main:not(#map) section {
-  padding-bottom: 1.4em;
+  padding-bottom: 0.25em;
 }
 main:not(#map) > article,
 main#search > div {
@@ -87,7 +87,7 @@ main#search > div {
 }
 
 main:not(#map) > article p {
-  padding: 1.2em 0;
+  padding: 0;
 }
 main:not(#map) > article > p,
 main:not(#map) > article > section p {
@@ -108,14 +108,27 @@ main:not(#map) > article::after {
   #app > section#content-wrapper {
     flex-direction: row;
   }
+  main:not(#map) .flex-spacer {
+    width: 350px;
+  }
   main:not(#map) > article,
   main#search > div {
     padding: 30px 30px 80px 30px;
   }
-  main:not(#map) .flex-spacer {
-    width: 350px;
+  main:not(#map) > article p {
+    padding: 1.2em 0;
   }
   main:not(#map) > article::after {
     padding-bottom: 4em;
+  }
+  main:not(#map) h1 {
+    margin-block-end: 1rem;
+  }
+  main:not(#map) h2 {
+    margin-block-start: 0.83rem;
+    margin-block-end: 0.83rem;
+  }
+  main:not(#map) section {
+    padding-bottom: 1.4em;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -54,7 +54,7 @@ main:not(#map) {
   width: 100%;
 }
 main:not(#map) .flex-spacer {
-  width: 350px;
+  width: 0px;
   box-sizing: border-box;
 }
 main:not(#map) h1 {
@@ -81,7 +81,7 @@ main:not(#map) section {
 }
 main:not(#map) > article,
 main#search > div {
-  padding: 30px 30px 80px 30px;
+  padding: 0 2rem;
   max-width: 980px;
   line-height: 1.7;
 }
@@ -100,5 +100,19 @@ main:not(#map) > article li {
 main:not(#map) > article::after {
   content: '';
   display: block;
-  padding-bottom: 4em;
+  padding-bottom: 1em;
+}
+
+/* medium-sized displays and larger */
+@media (min-width: 640px) {
+  main:not(#map) > article,
+  main#search > div {
+    padding: 30px 30px 80px 30px;
+  }
+  main:not(#map) .flex-spacer {
+    width: 350px;
+  }
+  main:not(#map) > article::after {
+    padding-bottom: 4em;
+  }
 }

--- a/src/pages/CreditsPage/CreditsPage.jsx
+++ b/src/pages/CreditsPage/CreditsPage.jsx
@@ -3,7 +3,7 @@ import './CreditsPage.css';
 /**
  * Credits page for ITSB (static content)
  *
- * @returns {React.Component} Credits page React functional component
+ * @returns {ReactElement} Credits page React functional component
  */
 export function CreditsPage() {
   return (

--- a/src/pages/ErrorPage/ErrorPage.jsx
+++ b/src/pages/ErrorPage/ErrorPage.jsx
@@ -5,7 +5,7 @@ import { useRouteError } from 'react-router-dom';
  * Error page using React Router to handle known errors, with static defaults.
  * Will not render in <Outlet> so requires its own Header.
  *
- * @returns {React.Component} Error page React functional component
+ * @returns {ReactElement} Error page React functional component
  */
 export function ErrorPage() {
   const error = useRouteError();

--- a/src/pages/HomePage/HomePage.css
+++ b/src/pages/HomePage/HomePage.css
@@ -1,8 +1,5 @@
 main#home aside {
-  float: right;
-  width: 30%;
   max-width: 235ch;
-  margin: 0.8rem 0 0 5rem;
 }
 main#home aside section.vis-info {
   margin-bottom: 3em;
@@ -20,4 +17,13 @@ main#home aside h2:first-child {
 }
 main#home aside p {
   margin: 0;
+}
+
+/* medium-sized displays and larger */
+@media (min-width: 640px) {
+  main#home aside {
+    float: right;
+    width: 30%;
+    margin: 0.8rem 0 0 5rem;
+  }
 }

--- a/src/pages/HomePage/HomePage.css
+++ b/src/pages/HomePage/HomePage.css
@@ -1,8 +1,14 @@
+main#home article {
+  display: flex;
+  flex-flow: column;
+}
 main#home aside {
+  order: 1;
   max-width: 235ch;
+  margin: 2rem 0;
 }
 main#home aside section.vis-info {
-  margin-bottom: 3em;
+  margin-bottom: 2em;
 }
 main#home aside section.vis-info p {
   font-size: 0.85rem;
@@ -21,9 +27,15 @@ main#home aside p {
 
 /* medium-sized displays and larger */
 @media (min-width: 640px) {
+  main#home article {
+    display: block;
+  }
   main#home aside {
     float: right;
     width: 30%;
     margin: 0.8rem 0 0 5rem;
+  }
+  main#home aside section.vis-info {
+    margin-bottom: 3em;
   }
 }

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -4,7 +4,7 @@ import './HomePage.css';
 /**
  * Home page for ITSB (static content)
  *
- * @returns {React.Component} Home page React functional component
+ * @returns {ReactElement} Home page React functional component
  */
 export function HomePage() {
   return (

--- a/src/pages/InstructionsPage/InstructionsPage.jsx
+++ b/src/pages/InstructionsPage/InstructionsPage.jsx
@@ -3,7 +3,7 @@ import './InstructionsPage.css';
 /**
  * Instructions page for ITSB (static content)
  *
- * @returns {React.Component} Instructions page React functional component
+ * @returns {ReactElement} Instructions page React functional component
  */
 export function InstructionsPage() {
   return (

--- a/src/pages/MapPage/MapPage.css
+++ b/src/pages/MapPage/MapPage.css
@@ -1,6 +1,5 @@
 aside#map-control {
-  flex: 0 0 330px;
-  padding: 20px 10px;
+  padding: 10px 0;
   background-color: var(--sidebar-bg);
 }
 
@@ -10,9 +9,10 @@ main#map {
 }
 
 aside#intersection-details {
-  flex: 0 0 330px;
+  flex: 0 0 22%;
   background-color: #fff;
   overflow-y: scroll;
+  font-size: 0.85rem;
 }
 
 aside#intersection-details h1 {
@@ -20,5 +20,21 @@ aside#intersection-details h1 {
 }
 
 aside#intersection-details p {
-  line-height: 1.6;
+  line-height: 1.33;
+  margin-top: 0;
+}
+
+/* medium-sized displays and larger */
+@media (min-width: 640px) {
+  aside#map-control {
+    flex: 0 0 330px;
+    padding: 20px 10px;
+  }
+  aside#intersection-details {
+    flex: 0 0 330px;
+    font-size: 1rem;
+  }
+  aside#intersection-details p {
+    line-height: 1.6;
+  }
 }

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -14,7 +14,7 @@ import './MapPage.css';
 /**
  * The page component for the map visualizations.
  *
- * @returns {React.Component} React map functional component
+ * @returns {ReactElement} React map functional component
  */
 export function MapPage() {
   const { loaded } = useOutletContext();

--- a/src/pages/SearchPage/SearchPage.css
+++ b/src/pages/SearchPage/SearchPage.css
@@ -7,11 +7,11 @@
   box-sizing: border-box;
 }
 #search .flex-spacer {
-  flex-shrink: 16;
+  padding: 0;
 }
 #search section {
-  padding: 60px 10px;
-  width: 980px;
+  padding: 30px 30px;
+  width: 100%;
   box-sizing: border-box;
 }
 #search section form {
@@ -43,4 +43,15 @@
   padding: 0 0 2.2em 0;
   font-size: 0.9em;
   max-width: 60ch;
+}
+
+/* medium-sized displays and larger */
+@media (min-width: 640px) {
+  #search section {
+    padding: 60px 10px;
+    width: 980px;
+  }
+  #search .flex-spacer {
+    flex-shrink: 16;
+  }
 }

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -11,7 +11,7 @@ import './SearchPage.css';
 /**
  * Search page for ITSB, using Peripleo search and filtering.
  *
- * @returns {React.Component} Search page React functional component
+ * @returns {ReactElement} Search page React functional component
  */
 export function SearchPage() {
   const { loaded } = useOutletContext();


### PR DESCRIPTION
## In this PR

- Per #48:
  - Add toggle-able mobile navigation using a checkbox input and hamburger icon
  - Overall reductions in padding, margins for mobile
  - Adapt content, search pages for mobile
  - Adapt home page for mobile by using flex column and placing the `aside` content last
  - Adapt map controls for mobile
    - Use flex column to stack controls vertically
    - Use a smaller font size and flex row-wrap on author select
- For consistency (and accuracy!), replace all `React.Component` return types with `ReactElement` in JSDoc