### PR TITLE
AuthorSelect design

### DIFF
--- a/src/components/AuthorSelect/AuthorSelect.css
+++ b/src/components/AuthorSelect/AuthorSelect.css
@@ -1,39 +1,62 @@
-ul.author-select {
+.author-select h2 {
+  font-weight: 500;
+  font-size: 1.17em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 5px;
+}
+
+.author-select button.select-all {
+  outline: none;
+  border: none;
+  font-size: 0.7em;
+  cursor: pointer;
+  padding: 4px 6px 3px 6px;
+}
+
+.author-select button.select-all:focus-visible {
+  border: 1px solid #000;
+  border-radius: 2px;
+}
+
+.author-select ul {
   list-style-type: none;
   padding: 0;
   margin: 0;
   font-size: 17px;
 }
 
-ul.author-select li input {
+.author-select li input {
   /** Unlike display: none, this keeps it on screen, **/
   /** and will keep input:focus + label working      **/
   opacity: 0;
   position: absolute;
 }
 
-ul.author-select li label {
+.author-select li label {
   display: block;
-  padding: 4px 8px;
+  padding: 0 8px;
   color: rgb(147, 147, 147);
   border-radius: 2px;
   cursor: pointer;
 }
 
-ul.author-select li label:hover,
-ul.author-select li input:focus-visible + label {
+.author-select li label:hover,
+.author-select li input:focus-visible + label {
   background-color: rgba(147, 147, 147, 0.12);
 }
 
-ul.author-select li input + label {
+.author-select li input + label {
+  padding: 5px;
   color: #6a727c;
 }
 
-ul.author-select li input:checked + label {
+.author-select li input:checked + label {
   color: var(--color);
 }
 
-ul.author-select li {
-  padding: 5px 0;
+.author-select li {
+  padding: 0;
   cursor: pointer;
 }

--- a/src/components/AuthorSelect/AuthorSelect.css
+++ b/src/components/AuthorSelect/AuthorSelect.css
@@ -65,7 +65,7 @@
 
 /* medium-sized displays and larger */
 @media (min-width: 640px) {
-  ul.author-select {
+  .author-select ul {
     font-size: 17px;
     display: block;
   }

--- a/src/components/AuthorSelect/AuthorSelect.css
+++ b/src/components/AuthorSelect/AuthorSelect.css
@@ -56,6 +56,7 @@
 
 .author-select li input:checked + label {
   color: var(--color);
+  font-weight: bold;
 }
 
 .author-select li {

--- a/src/components/AuthorSelect/AuthorSelect.css
+++ b/src/components/AuthorSelect/AuthorSelect.css
@@ -2,15 +2,38 @@ ul.author-select {
   list-style-type: none;
   padding: 0;
   margin: 0;
-  font-size: 17px; 
+  font-size: 17px;
 }
 
-ul.author-select li {
-  padding: 5px;
-  cursor: pointer;
+ul.author-select li input {
+  /** Unlike display: none, this keeps it on screen, **/
+  /** and will keep input:focus + label working      **/
+  opacity: 0;
+  position: absolute;
 }
 
 ul.author-select li label {
+  display: block;
+  padding: 4px 8px;
+  color: rgb(147, 147, 147);
+  border-radius: 2px;
   cursor: pointer;
-  padding-left: 5px;
-} 
+}
+
+ul.author-select li label:hover,
+ul.author-select li input:focus-visible + label {
+  background-color: rgba(147, 147, 147, 0.12);
+}
+
+ul.author-select li input + label {
+  color: #6a727c;
+}
+
+ul.author-select li input:checked + label {
+  color: var(--color);
+}
+
+ul.author-select li {
+  padding: 5px 0;
+  cursor: pointer;
+}

--- a/src/components/AuthorSelect/AuthorSelect.jsx
+++ b/src/components/AuthorSelect/AuthorSelect.jsx
@@ -15,28 +15,44 @@ export const AuthorSelect = () => {
     setFilter({ name: 'authors', values: updated });
   };
 
-  return (
-    <ul className="author-select">
-      {authors.map((author) => (
-        <li key={author.id}>
-          <input
-            type="checkbox"
-            id={`${author.id}-checkbox`}
-            name={author.id}
-            checked={selected.includes(author.id)}
-            onChange={toggleAuthor(author.id)}
-          />
+  /**
+   * Behavior: clicking the button will select ALL AUTHORS, unless
+   * all authors are already selected. If all are selected, this button
+   * deselects all.
+   */
+  const toggleAll = () => {
+    if (selected.length < authors.length) {
+      setFilter({ name: 'authors', values: authors.map((a) => a.id) });
+    } else {
+      setFilter({ name: 'authors', values: [] });
+    }
+  };
 
-          <label
-            htmlFor={`${author.id}-checkbox`}
-            style={{
-              '--color': `rgba(${author.color.join(',')})`,
-            }}
-          >
-            {author.name}
-          </label>
-        </li>
-      ))}
-    </ul>
+  return (
+    <div>
+      <button onClick={toggleAll}>All</button>
+      <ul className="author-select">
+        {authors.map((author) => (
+          <li key={author.id}>
+            <input
+              type="checkbox"
+              id={`${author.id}-checkbox`}
+              name={author.id}
+              checked={selected.includes(author.id)}
+              onChange={toggleAuthor(author.id)}
+            />
+
+            <label
+              htmlFor={`${author.id}-checkbox`}
+              style={{
+                '--color': `rgba(${author.color.join(',')})`,
+              }}
+            >
+              {author.name}
+            </label>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 };

--- a/src/components/AuthorSelect/AuthorSelect.jsx
+++ b/src/components/AuthorSelect/AuthorSelect.jsx
@@ -30,7 +30,7 @@ export const AuthorSelect = () => {
           <label
             htmlFor={`${author.id}-checkbox`}
             style={{
-              color: `rgba(${author.color.join(',')})`,
+              '--color': `rgba(${author.color.join(',')})`,
             }}
           >
             {author.name}

--- a/src/components/AuthorSelect/AuthorSelect.jsx
+++ b/src/components/AuthorSelect/AuthorSelect.jsx
@@ -33,7 +33,7 @@ export const AuthorSelect = () => {
       <h2>
         <span>Select Authors</span>
         <button className="select-all" onClick={toggleAll}>
-          <span>Select all</span>
+          {selected.length < authors.length ? <span>Select all</span> : <span>Deselect all</span>}
         </button>
       </h2>
 

--- a/src/components/AuthorSelect/AuthorSelect.jsx
+++ b/src/components/AuthorSelect/AuthorSelect.jsx
@@ -29,9 +29,15 @@ export const AuthorSelect = () => {
   };
 
   return (
-    <div>
-      <button onClick={toggleAll}>All</button>
-      <ul className="author-select">
+    <div className="author-select">
+      <h2>
+        <span>Select Authors</span>
+        <button className="select-all" onClick={toggleAll}>
+          <span>Select all</span>
+        </button>
+      </h2>
+
+      <ul>
         {authors.map((author) => (
           <li key={author.id}>
             <input


### PR DESCRIPTION
# In this PR

- Per #34, this PR removes the checkboxes from the AuthorSelect component.
  - Checkboxes are still in the markup but hidden with CSS, to keep the markup semantically clean. 
  - As additional hint to the user, the component now has a "Select Authors" heading
  - Tab navigation remains possible (Tab for next, Shift+Tab for previous, Space to toggle checked state), with a visual style indicating which Author has focus 
- Per #45, this PR adds a "Select All" button (next to the heading)
  - The button will select all authors, as long as there is at least one un-selected author
  - If all authors are selected, the button will deselect all