### PR TITLE
Add legend to intersections visualization (#37)

### DIFF
--- a/src/components/AuthorSelect/AuthorSelect.css
+++ b/src/components/AuthorSelect/AuthorSelect.css
@@ -87,7 +87,7 @@
 }
 
 .author-select li input + label {
-  color: #6a727c;
+  color: var(--dimmed-text);
 }
 
 .author-select li input:checked + label {

--- a/src/components/IntersectionsLegend/IntersectionsLegend.css
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.css
@@ -1,4 +1,4 @@
-legend#interesction-legend {
+legend#intersection-legend {
   display: none; /* hide entirely on mobile */
   position: absolute;
   row-gap: 0.5rem;
@@ -15,41 +15,41 @@ legend#interesction-legend {
   transition: opacity 0.5s;
   opacity: 1;
 }
-legend#interesction-legend.hidden {
+legend#intersection-legend.hidden {
   opacity: 0%;
   pointer-events: none;
 }
-legend#interesction-legend h2 {
+legend#intersection-legend h2 {
   margin: 0;
   font-size: 1rem;
   grid-column-start: 1;
   grid-column-end: 3;
 }
-legend#interesction-legend p {
+legend#intersection-legend p {
   margin: 0;
   font-size: 0.83rem;
 }
 
 /* circle/ring inline svgs */
-legend#interesction-legend svg {
+legend#intersection-legend svg {
   width: 1.5rem;
   height: 1.5rem;
   margin: 0 0 0 auto;
 }
-legend#interesction-legend svg ellipse {
+legend#intersection-legend svg ellipse {
   stroke: rgb(200, 100, 0);
   fill: rgb(252, 176, 64);
   stroke-width: 0.25px;
 }
-legend#interesction-legend svg ellipse.middle {
+legend#intersection-legend svg ellipse.middle {
   fill: rgba(252, 176, 64, 0.5);
 }
-legend#interesction-legend svg ellipse.outer {
+legend#intersection-legend svg ellipse.outer {
   fill: rgb(252, 176, 64, 0.25);
 }
 
 /* close button */
-legend#interesction-legend button {
+legend#intersection-legend button {
   position: absolute;
   width: 100%;
   height: 100%;
@@ -67,7 +67,7 @@ legend#interesction-legend button {
 }
 /* medium-sized displays and larger */
 @media (min-width: 640px) {
-  legend#interesction-legend {
+  legend#intersection-legend {
     display: grid;
   }
 }

--- a/src/components/IntersectionsLegend/IntersectionsLegend.css
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.css
@@ -36,15 +36,15 @@ legend#intersection-legend svg {
   height: 1.5rem;
   margin: 0 0 0 auto;
 }
-legend#intersection-legend svg ellipse {
+legend#intersection-legend svg circle {
   stroke: rgb(200, 100, 0);
   fill: rgb(252, 176, 64);
   stroke-width: 0.25px;
 }
-legend#intersection-legend svg ellipse.middle {
+legend#intersection-legend svg circle.middle {
   fill: rgba(252, 176, 64, 0.5);
 }
-legend#intersection-legend svg ellipse.outer {
+legend#intersection-legend svg circle.outer {
   fill: rgb(252, 176, 64, 0.25);
 }
 

--- a/src/components/IntersectionsLegend/IntersectionsLegend.css
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.css
@@ -1,0 +1,73 @@
+legend#interesction-legend {
+  display: none; /* hide entirely on mobile */
+  position: absolute;
+  row-gap: 0.5rem;
+  width: 280px;
+  bottom: 1rem;
+  left: 0;
+  right: 0;
+  grid-template-columns: 5fr 1fr;
+  padding: 0.5rem 1rem;
+  margin: 0 auto;
+  align-items: center;
+  background-color: white;
+  border: 2px solid var(--gold);
+  transition: opacity 0.5s;
+  opacity: 1;
+}
+legend#interesction-legend.hidden {
+  opacity: 0%;
+  pointer-events: none;
+}
+legend#interesction-legend h2 {
+  margin: 0;
+  font-size: 1rem;
+  grid-column-start: 1;
+  grid-column-end: 3;
+}
+legend#interesction-legend p {
+  margin: 0;
+  font-size: 0.83rem;
+}
+
+/* circle/ring inline svgs */
+legend#interesction-legend svg {
+  width: 1.5rem;
+  height: 1.5rem;
+  margin: 0 0 0 auto;
+}
+legend#interesction-legend svg ellipse {
+  stroke: rgb(200, 100, 0);
+  fill: rgb(252, 176, 64);
+  stroke-width: 0.25px;
+}
+legend#interesction-legend svg ellipse.middle {
+  fill: rgba(252, 176, 64, 0.5);
+}
+legend#interesction-legend svg ellipse.outer {
+  fill: rgb(252, 176, 64, 0.25);
+}
+
+/* close button */
+legend#interesction-legend button {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  padding: 0.6rem 1rem;
+  font-family: 'DM Sans', Arial, Helvetica, sans-serif;
+  color: var(--dimmed-text);
+  cursor: pointer;
+  font-size: 0.83rem;
+}
+/* medium-sized displays and larger */
+@media (min-width: 640px) {
+  legend#interesction-legend {
+    display: grid;
+  }
+}

--- a/src/components/IntersectionsLegend/IntersectionsLegend.css
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.css
@@ -22,8 +22,6 @@ legend#intersection-legend.hidden {
 legend#intersection-legend h2 {
   margin: 0;
   font-size: 1rem;
-  grid-column-start: 1;
-  grid-column-end: 3;
 }
 legend#intersection-legend p {
   margin: 0;
@@ -50,24 +48,31 @@ legend#intersection-legend svg circle.outer {
 
 /* close button */
 legend#intersection-legend button {
-  position: absolute;
-  width: 100%;
-  height: 100%;
   background-color: transparent;
   border: none;
-  outline: none;
+  border-radius: 12px;
   display: flex;
-  align-items: flex-start;
-  justify-content: flex-end;
-  padding: 0.6rem 1rem;
-  font-family: 'DM Sans', Arial, Helvetica, sans-serif;
-  color: var(--dimmed-text);
+  align-items: center;
+  padding: 0;
   cursor: pointer;
-  font-size: 0.83rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin: 0 0 0 auto;
 }
+/* expand/collapse button, still visible when collapsed */
+button#expand-legend {
+  display: none; /* hide on mobile */
+  position: absolute;
+  bottom: 1rem;
+  left: calc(350px + 1.5rem);
+}
+
 /* medium-sized displays and larger */
 @media (min-width: 640px) {
   legend#intersection-legend {
     display: grid;
+  }
+  button#expand-legend {
+    display: flex;
   }
 }

--- a/src/components/IntersectionsLegend/IntersectionsLegend.jsx
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.jsx
@@ -17,14 +17,14 @@ export function IntersectionsLegend() {
       <p>Rings indicate possible intersections.</p>
       <svg viewBox="-1 -1 14 14" xmlns="http://www.w3.org/2000/svg">
         <title>A graphic of concentric rings representing possible intersections</title>
-        <ellipse className="outer" cx={6} cy={6} rx={6} ry={6}></ellipse>
-        <ellipse className="middle" cx={6} cy={6} rx={4} ry={4}></ellipse>
-        <ellipse className="inner" cx={6} cy={6} rx={2} ry={2}></ellipse>
+        <circle className="outer" cx={6} cy={6} r={6}></circle>
+        <circle className="middle" cx={6} cy={6} r={4}></circle>
+        <circle className="inner" cx={6} cy={6} r={2}></circle>
       </svg>
       <p>Solid circles indicate definite intersections.</p>
       <svg viewBox="-1 -1 14 14" xmlns="http://www.w3.org/2000/svg">
         <title>A graphic of a single solid circle representing a definite intersection</title>
-        <ellipse className="inner" cx={6} cy={6} rx={6} ry={6}></ellipse>
+        <circle className="inner" cx={6} cy={6} r={6}></circle>
       </svg>
     </legend>
   );

--- a/src/components/IntersectionsLegend/IntersectionsLegend.jsx
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.jsx
@@ -9,7 +9,7 @@ import './IntersectionsLegend.css';
 export function IntersectionsLegend() {
   const [visible, setVisible] = useState(true);
   return (
-    <legend id="interesction-legend" className={visible ? 'visible' : 'hidden'}>
+    <legend id="intersection-legend" className={visible ? 'visible' : 'hidden'}>
       <h2>Legend</h2>
       <button type="button" onClick={() => setVisible(false)} aria-hidden="true">
         (click to close)

--- a/src/components/IntersectionsLegend/IntersectionsLegend.jsx
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.jsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import './IntersectionsLegend.css';
+
+/**
+ * A legend for the intersections visualization, adapted from the original ITSB project.
+ *
+ * @returns {ReactElement} Legend React functional component
+ */
+export function IntersectionsLegend() {
+  const [visible, setVisible] = useState(true);
+  return (
+    <legend id="interesction-legend" className={visible ? 'visible' : 'hidden'}>
+      <h2>Legend</h2>
+      <button type="button" onClick={() => setVisible(false)} aria-hidden="true">
+        (click to close)
+      </button>
+      <p>Rings indicate possible intersections.</p>
+      <svg viewBox="-1 -1 14 14" xmlns="http://www.w3.org/2000/svg">
+        <title>A graphic of concentric rings representing possible intersections</title>
+        <ellipse className="outer" cx={6} cy={6} rx={6} ry={6}></ellipse>
+        <ellipse className="middle" cx={6} cy={6} rx={4} ry={4}></ellipse>
+        <ellipse className="inner" cx={6} cy={6} rx={2} ry={2}></ellipse>
+      </svg>
+      <p>Solid circles indicate definite intersections.</p>
+      <svg viewBox="-1 -1 14 14" xmlns="http://www.w3.org/2000/svg">
+        <title>A graphic of a single solid circle representing a definite intersection</title>
+        <ellipse className="inner" cx={6} cy={6} rx={6} ry={6}></ellipse>
+      </svg>
+    </legend>
+  );
+}

--- a/src/components/IntersectionsLegend/IntersectionsLegend.jsx
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.jsx
@@ -1,31 +1,43 @@
-import { useState } from 'react';
+import { BsInfoLg, BsX } from 'react-icons/bs';
 import './IntersectionsLegend.css';
 
 /**
  * A legend for the intersections visualization, adapted from the original ITSB project.
  *
- * @returns {ReactElement} Legend React functional component
+ * @param {React.ComponentProps} props React component props
+ * @param {Function} props.onClick Event handler to toggle the legend expanded/collapsed
+ * @param {boolean} props.visible Visible state boolean for the legend
+ * @returns {React.ReactElement} Legend React functional component
  */
-export function IntersectionsLegend() {
-  const [visible, setVisible] = useState(true);
+export function IntersectionsLegend({ onClick, visible }) {
   return (
-    <legend id="intersection-legend" className={visible ? 'visible' : 'hidden'}>
-      <h2>Legend</h2>
-      <button type="button" onClick={() => setVisible(false)} aria-hidden="true">
-        (click to close)
+    <>
+      <legend id="intersection-legend" className={visible ? 'visible' : 'hidden'}>
+        <h2>Legend</h2>
+        <button type="button" onClick={onClick} aria-label="Click to collapse legend">
+          <BsX />
+        </button>
+        <p>Rings indicate possible intersections.</p>
+        <svg viewBox="-1 -1 14 14" xmlns="http://www.w3.org/2000/svg">
+          <title>A graphic of concentric rings representing possible intersections</title>
+          <circle className="outer" cx={6} cy={6} r={6}></circle>
+          <circle className="middle" cx={6} cy={6} r={4}></circle>
+          <circle className="inner" cx={6} cy={6} r={2}></circle>
+        </svg>
+        <p>Solid circles indicate definite intersections.</p>
+        <svg viewBox="-1 -1 14 14" xmlns="http://www.w3.org/2000/svg">
+          <title>A graphic of a single solid circle representing a definite intersection</title>
+          <circle className="inner" cx={6} cy={6} r={6}></circle>
+        </svg>
+      </legend>
+      <button
+        id="expand-legend"
+        className="p6o-controls-btn"
+        onClick={onClick}
+        aria-label="Click to expand/collapse legend"
+      >
+        <BsInfoLg />
       </button>
-      <p>Rings indicate possible intersections.</p>
-      <svg viewBox="-1 -1 14 14" xmlns="http://www.w3.org/2000/svg">
-        <title>A graphic of concentric rings representing possible intersections</title>
-        <circle className="outer" cx={6} cy={6} r={6}></circle>
-        <circle className="middle" cx={6} cy={6} r={4}></circle>
-        <circle className="inner" cx={6} cy={6} r={2}></circle>
-      </svg>
-      <p>Solid circles indicate definite intersections.</p>
-      <svg viewBox="-1 -1 14 14" xmlns="http://www.w3.org/2000/svg">
-        <title>A graphic of a single solid circle representing a definite intersection</title>
-        <circle className="inner" cx={6} cy={6} r={6}></circle>
-      </svg>
-    </legend>
+    </>
   );
 }

--- a/src/components/IntersectionsLegend/index.js
+++ b/src/components/IntersectionsLegend/index.js
@@ -1,0 +1,1 @@
+export * from './IntersectionsLegend';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,7 @@ export * from './AuthorSelect';
 export * from './Header';
 export * from './IntersectionDetails';
 export * from './IntersectionsLayer';
+export * from './IntersectionsLegend';
 export * from './ItinerariesLayer';
 export * from './ITSBStore';
 export * from './ITSBTooltip';

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@
   --navbar-bg: black;
   --navbar-link: white;
   --sidebar-bg: #f0f1f2;
+  --dimmed-text: #6a727c;
 }
 
 .btn {

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -6,6 +6,7 @@ import {
   ItinerariesLayer,
   IntersectionDetails,
   IntersectionsLayer,
+  IntersectionsLegend,
   MonthRangeInput,
 } from '../../components';
 import { useMatch, useOutletContext } from 'react-router-dom';
@@ -57,9 +58,12 @@ export function MapPage() {
         </main>
 
         {!isTrajectories && (
-          <aside id="intersection-details">
-            <IntersectionDetails at={selectedIntersection} />
-          </aside>
+          <>
+            <aside id="intersection-details">
+              <IntersectionDetails at={selectedIntersection} />
+            </aside>
+            <IntersectionsLegend />
+          </>
         )}
       </>
     )

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -20,10 +20,13 @@ import './MapPage.css';
 export function MapPage() {
   const { loaded } = useOutletContext();
 
+  const [legendVisible, setLegendVisible] = useState(true);
+  const toggleLegend = () => {
+    setLegendVisible((prev) => !prev);
+  };
+
   const [selectedIntersection, setSelectedIntersection] = useState();
-
   const isTrajectories = useMatch('trajectories');
-
   const layer = isTrajectories
     ? ItinerariesLayer()
     : IntersectionsLayer({ selected: selectedIntersection });
@@ -62,7 +65,7 @@ export function MapPage() {
             <aside id="intersection-details">
               <IntersectionDetails at={selectedIntersection} />
             </aside>
-            <IntersectionsLegend />
+            <IntersectionsLegend onClick={toggleLegend} visible={legendVisible} />
           </>
         )}
       </>

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -20,9 +20,13 @@ import './MapPage.css';
 export function MapPage() {
   const { loaded } = useOutletContext();
 
-  const [legendVisible, setLegendVisible] = useState(true);
+  const storedHidden = localStorage.getItem('itsb-legend');
+  const [legendVisible, setLegendVisible] = useState(!storedHidden);
   const toggleLegend = () => {
     setLegendVisible((prev) => !prev);
+    if (!storedHidden) {
+      localStorage.setItem('itsb-legend', 'hidden');
+    }
   };
 
   const [selectedIntersection, setSelectedIntersection] = useState();

--- a/src/pages/SearchPage/SearchPage.css
+++ b/src/pages/SearchPage/SearchPage.css
@@ -34,7 +34,7 @@
   margin: 0;
   padding: 0 0 0.3em 0;
   font-size: 0.9em;
-  color: #6a727c;
+  color: var(--dimmed-text);
   font-weight: normal;
 }
 


### PR DESCRIPTION
## In this PR

- Per #37:
  - Add legend to intersections viz that can be hidden on click
- Factor out reused color `--dimmed-text`

## Questions

- How do you feel about "click to close" and the way hiding works in general? I just mimicked the behavior from the old ITSB page but I'm not sure I love it—both clicking the entire legend to close it, and the fact that it reappears every time you visit the page.
- How do you feel about hiding this legend entirely on mobile? I couldn't figure out a nice way to make it visible on mobile without covering something else up.