### PR TITLE
Add detail to trajectory tooltips (#35)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,7 +30,10 @@
     "jsdoc/newline-after-description": 1,
     "jsdoc/no-multi-asterisks": 1,
     "jsdoc/require-jsdoc": 1,
-    "jsdoc/require-param": 1,
+    "jsdoc/require-param": [
+      "warn",
+      { "unnamedRootBase": ["props", "args"], "checkDestructured": true }
+    ],
     "jsdoc/require-param-description": 1,
     "jsdoc/require-param-name": 1,
     "jsdoc/require-param-type": 1,

--- a/src/components/ITSBStore/utils/itineraryUtils.js
+++ b/src/components/ITSBStore/utils/itineraryUtils.js
@@ -25,3 +25,18 @@ export const splitItinerary = (it) => {
 
   return sortWaypointsByTime(waypoints);
 };
+
+/**
+ * Given a list of itineraries, return all the waypoints
+ * at the passed place ID.
+ *
+ * @param {Array<*>|undefined} itineraries List of itineraries
+ * @param {string} place Place ID to match
+ * @returns {Array<*>} List of waypoints
+ */
+export const waypointsAtPlace = (itineraries, place) => {
+  return (itineraries || []).reduce((all, it) => {
+    const { waypoints } = it;
+    return [...all, ...waypoints.filter((wp) => wp.place === place)];
+  }, []);
+};

--- a/src/components/ITSBTooltip/ITSBTooltip.js
+++ b/src/components/ITSBTooltip/ITSBTooltip.js
@@ -1,19 +1,4 @@
-import { sortWaypointsByTime } from '../ITSBStore';
-
-/**
- * Format the date by moving the year to the end and changing dash delimiters
- * to slashes; or return a question mark if there is no date.
- *
- * @param {string} date The date as a string formatted YYYY-MM-DD.
- * @returns {string} Date formatted MM/DD/YYYY.
- */
-function fmt(date) {
-  const split = date?.split('-');
-  if (split?.length) {
-    split.push(split.shift());
-  }
-  return split?.join('/') || '?';
-}
+import { formatInterval, sortWaypointsByTime } from '../ITSBStore';
 
 /**
  * Generate tooltip markup for a waypoint in an itinerary, or a place with
@@ -52,10 +37,7 @@ export function ITSBTooltip({ graph, object, search }) {
         // format is "Name: Label (StartDate–EndDate)"
         let label = relation.label ? `${name}: ${relation.label}` : name;
         if (when.timespans.length) {
-          const { start, end } = when.timespans[0];
-          const startDate = start?.in || start?.earliest;
-          const endDate = end?.in || end?.latest;
-          label = `${label} (${fmt(startDate)}–${fmt(endDate)})`;
+          label = `${label} (${formatInterval(waypoint)})`;
         }
         selected.push(`<li>${label}</li>`);
       }

--- a/src/components/ITSBTooltip/ITSBTooltip.js
+++ b/src/components/ITSBTooltip/ITSBTooltip.js
@@ -1,4 +1,4 @@
-import { formatInterval, sortWaypointsByTime } from '../ITSBStore';
+import { formatInterval, sortWaypointsByTime, waypointsAtPlace } from '../ITSBStore';
 
 /**
  * Generate tooltip markup for a waypoint in an itinerary, or a place with
@@ -18,13 +18,8 @@ export function ITSBTooltip({ graph, object, search }) {
     // for trajectories, show place name and labeled waypoints
     const selected = [`<h2>${object.properties?.title || 'Place'}</h2>`, '<ul>'];
 
-    // Get all waypoints on this place
-    const waypointsAtThisPlace = search.result.items?.reduce((all, it) => {
-      const { waypoints } = it;
-      return [...all, ...waypoints.filter((wp) => wp.place === object.id)];
-    }, []);
-    // sort them by time
-    const sorted = waypointsAtThisPlace && sortWaypointsByTime(waypointsAtThisPlace);
+    // Get all waypoints on this place, sort them by time
+    const sorted = sortWaypointsByTime(waypointsAtPlace(search.result.items, object.id));
     const anyHasLabel = sorted.some((waypoint) => waypoint.relation?.label);
     sorted.forEach((waypoint) => {
       const { author, relation, when } = waypoint;

--- a/src/components/ITSBTooltip/ITSBTooltip.js
+++ b/src/components/ITSBTooltip/ITSBTooltip.js
@@ -1,3 +1,68 @@
-export const ITSBTooltip = ({ object }) => {
-  return object?.properties?.title;
-};
+import { sortWaypointsByTime } from '../ITSBStore';
+
+/**
+ * Format the date by moving the year to the end and changing dash delimiters
+ * to slashes; or return a question mark if there is no date.
+ *
+ * @param {string} date The date as a string formatted YYYY-MM-DD.
+ * @returns {string} Date formatted MM/DD/YYYY.
+ */
+function fmt(date) {
+  const split = date?.split('-');
+  if (split?.length) {
+    split.push(split.shift());
+  }
+  return split?.join('/') || '?';
+}
+
+/**
+ * Generate a tooltip string for a waypoint in an itinerary, or a place with
+ * intersecitons.
+ *
+ * @param {*} props Arguments object to destructure
+ * @param {*} props.graph The ITSB graph context provider
+ * @param {*} props.object The currently selected waypoint
+ * @param {*} props.search The ITSB search context provider
+ * @returns {string|undefined} The tooltip text, if possible
+ */
+export function ITSBTooltip({ graph, object, search }) {
+  if (object) {
+    if (object.present) {
+      // present means this tooltip is for intersections; just use place name
+      return object.properties.title;
+    } else {
+      // for trajectories, show place name and labeled waypoints
+      const selected = [object.properties.title];
+
+      // Get all waypoints on this place
+      const waypointsAtThisPlace = search.result.items?.reduce((all, it) => {
+        const { waypoints } = it;
+        return [...all, ...waypoints.filter((wp) => wp.place === object.id)];
+      }, []);
+      // sort them by time
+      const sorted = waypointsAtThisPlace && sortWaypointsByTime(waypointsAtThisPlace);
+      const anyHasLabel = sorted.some((waypoint) => waypoint.relation.label);
+      sorted.forEach((waypoint) => {
+        const { author, relation, when } = waypoint;
+        // if this waypoint has relation.label or NONE on this place do, then
+        // add it to the tooltip.
+        // if some waypoint on this place has relation.label but this one does
+        // not, skip this waypoint.
+        if (relation.label || !anyHasLabel) {
+          const { name } = graph.getNode(author);
+          // format is "Name: Label (StartDate–EndDate)"
+          let label = relation.label ? `${name}: ${relation.label}` : name;
+          if (when.timespans.length) {
+            const { start, end } = when.timespans[0];
+            const startDate = start?.in || start?.earliest;
+            const endDate = end?.in || end?.latest;
+            label = `${label} (${fmt(startDate)}–${fmt(endDate)})`;
+          }
+          selected.push(label);
+        }
+      });
+      // since we can only use strings here, join by newline (will become <br>)
+      return selected.join('\n');
+    }
+  }
+}

--- a/src/components/ITSBTooltip/ITSBTooltip.js
+++ b/src/components/ITSBTooltip/ITSBTooltip.js
@@ -26,43 +26,41 @@ function fmt(date) {
  * @returns {string|undefined} The tooltip text, if possible
  */
 export function ITSBTooltip({ graph, object, search }) {
-  if (object) {
-    if (object.present) {
-      // present means this tooltip is for intersections; just use place name
-      return object.properties.title;
-    } else {
-      // for trajectories, show place name and labeled waypoints
-      const selected = [object.properties.title];
+  if (object?.present) {
+    // present means this tooltip is for intersections; just use place name
+    return object.properties?.title;
+  } else if (object) {
+    // for trajectories, show place name and labeled waypoints
+    const selected = [object.properties?.title || ''];
 
-      // Get all waypoints on this place
-      const waypointsAtThisPlace = search.result.items?.reduce((all, it) => {
-        const { waypoints } = it;
-        return [...all, ...waypoints.filter((wp) => wp.place === object.id)];
-      }, []);
-      // sort them by time
-      const sorted = waypointsAtThisPlace && sortWaypointsByTime(waypointsAtThisPlace);
-      const anyHasLabel = sorted.some((waypoint) => waypoint.relation.label);
-      sorted.forEach((waypoint) => {
-        const { author, relation, when } = waypoint;
-        // if this waypoint has relation.label or NONE on this place do, then
-        // add it to the tooltip.
-        // if some waypoint on this place has relation.label but this one does
-        // not, skip this waypoint.
-        if (relation.label || !anyHasLabel) {
-          const { name } = graph.getNode(author);
-          // format is "Name: Label (StartDate–EndDate)"
-          let label = relation.label ? `${name}: ${relation.label}` : name;
-          if (when.timespans.length) {
-            const { start, end } = when.timespans[0];
-            const startDate = start?.in || start?.earliest;
-            const endDate = end?.in || end?.latest;
-            label = `${label} (${fmt(startDate)}–${fmt(endDate)})`;
-          }
-          selected.push(label);
+    // Get all waypoints on this place
+    const waypointsAtThisPlace = search.result.items?.reduce((all, it) => {
+      const { waypoints } = it;
+      return [...all, ...waypoints.filter((wp) => wp.place === object.id)];
+    }, []);
+    // sort them by time
+    const sorted = waypointsAtThisPlace && sortWaypointsByTime(waypointsAtThisPlace);
+    const anyHasLabel = sorted.some((waypoint) => waypoint.relation?.label);
+    sorted.forEach((waypoint) => {
+      const { author, relation, when } = waypoint;
+      // if this waypoint has relation.label or NONE on this place do, then
+      // add it to the tooltip.
+      // if some waypoint on this place has relation.label but this one does
+      // not, skip this waypoint.
+      if (relation.label || !anyHasLabel) {
+        const { name } = graph.getNode(author);
+        // format is "Name: Label (StartDate–EndDate)"
+        let label = relation.label ? `${name}: ${relation.label}` : name;
+        if (when.timespans.length) {
+          const { start, end } = when.timespans[0];
+          const startDate = start?.in || start?.earliest;
+          const endDate = end?.in || end?.latest;
+          label = `${label} (${fmt(startDate)}–${fmt(endDate)})`;
         }
-      });
-      // since we can only use strings here, join by newline (will become <br>)
-      return selected.join('\n');
-    }
+        selected.push(label);
+      }
+    });
+    // since we can only use strings here, join by newline (will become <br>)
+    return selected.join('\n');
   }
 }

--- a/src/components/ITSBTooltip/ITSBTooltip.js
+++ b/src/components/ITSBTooltip/ITSBTooltip.js
@@ -16,7 +16,7 @@ function fmt(date) {
 }
 
 /**
- * Generate a tooltip string for a waypoint in an itinerary, or a place with
+ * Generate tooltip markup for a waypoint in an itinerary, or a place with
  * intersecitons.
  *
  * @param {*} props Arguments object to destructure
@@ -31,7 +31,7 @@ export function ITSBTooltip({ graph, object, search }) {
     return object.properties?.title;
   } else if (object) {
     // for trajectories, show place name and labeled waypoints
-    const selected = [object.properties?.title || ''];
+    const selected = [`<h2>${object.properties?.title || 'Place'}</h2>`, '<ul>'];
 
     // Get all waypoints on this place
     const waypointsAtThisPlace = search.result.items?.reduce((all, it) => {
@@ -57,10 +57,10 @@ export function ITSBTooltip({ graph, object, search }) {
           const endDate = end?.in || end?.latest;
           label = `${label} (${fmt(startDate)}–${fmt(endDate)})`;
         }
-        selected.push(label);
+        selected.push(`<li>${label}</li>`);
       }
     });
-    // since we can only use strings here, join by newline (will become <br>)
-    return selected.join('\n');
+    selected.push('</ul>');
+    return { html: selected.join('\n') };
   }
 }

--- a/src/components/IntersectionDetails/IntersectionDetails.jsx
+++ b/src/components/IntersectionDetails/IntersectionDetails.jsx
@@ -3,6 +3,7 @@ import {
   estimateInterval,
   formatInterval,
   sortWaypointsByTime,
+  waypointsAtPlace,
 } from '../../components/ITSBStore/utils';
 
 import './IntersectionDetails.css';
@@ -17,13 +18,8 @@ export const IntersectionDetails = (props) => {
   // Itineraries in the current search (filtered by author and time)
   const itineraries = at ? search.result?.items : null;
 
-  // Get all waypoints on this place
-  const waypointsAtThisPlace = itineraries?.reduce((all, it) => {
-    const { waypoints } = it;
-    return [...all, ...waypoints.filter((wp) => wp.place === at.id)];
-  }, []);
-
-  const sorted = waypointsAtThisPlace && sortWaypointsByTime(waypointsAtThisPlace);
+  // Get all waypoints on this place, sort them by time
+  const sorted = sortWaypointsByTime(waypointsAtPlace(itineraries, at?.id));
 
   const getLikelihood = (waypoint) => estimateInterval(waypoint, graph)?.likelihood;
 

--- a/src/pages/MapPage/MapPage.css
+++ b/src/pages/MapPage/MapPage.css
@@ -8,6 +8,11 @@ main#map {
   flex-grow: 1;
 }
 
+.deck-tooltip {
+  font-size: 0.8rem;
+  max-width: 450px;
+}
+
 /* medium-sized displays and larger */
 @media (min-width: 640px) {
   aside#map-control {

--- a/src/pages/MapPage/MapPage.css
+++ b/src/pages/MapPage/MapPage.css
@@ -12,6 +12,14 @@ main#map {
   font-size: 0.8rem;
   max-width: 450px;
 }
+.deck-tooltip h2 {
+  font-size: 0.8rem;
+  margin: 0;
+}
+.deck-tooltip ul {
+  margin: 0;
+  padding: 0 0 0 1rem;
+}
 
 /* medium-sized displays and larger */
 @media (min-width: 640px) {


### PR DESCRIPTION
## In this PR

- Per #35:
  - In the trajectories visualization, when a user hovers over a place marker, display a list of waypoints on that place for the selected authors and time range
- Improve ESLint autofix behavior for destructured function arguments

## Questions

- Should we pull out the following snippet and make it reusable? It's copy pasted from `IntersectionDetails` right now, not DRY! Just wasn't sure where to put it since it's a combo of reducing the search results and filtering the waypoints.
  https://github.com/performant-software/itsb/blob/a1b8effd804e33e11b2b838a3b6c996cd06802f7/src/components/ITSBTooltip/ITSBTooltip.js#L36-L40
- I tried to keep the tooltips as minimal as possible, and one way of doing this is that I only show "unlabeled" waypoints (i.e. only author/year but no `relation.label`) when there are _no_ waypoints with a label on that place. Do you think that solution is ok? Is it misleading to only _sometimes_ surface that data?
  - Here's basically why I made this change: [displaying all](https://user-images.githubusercontent.com/7234006/205166468-bdc096fb-f894-4fd9-be0b-5ce780d3c6e5.png) vs [skipping "unlabeled"](https://user-images.githubusercontent.com/7234006/205166406-45c13092-3294-41e1-b7e0-38e51206d6ad.png). But maybe having the full time range selected is an unusual use case?
- I think this is the first time I'm really interacting with the search and graph providers in my code; did I make any mistakes? 😅 
- I wonder if it's possible to keep toolips from overflowing the viewport… but probably out of scope for this, unless we just want to reduce the `max-width`.