### PR TITLE
A workaround to prevent the intersections panel to shrink/grow on mobile

### DIFF
--- a/src/components/IntersectionDetails/IntersectionDetails.css
+++ b/src/components/IntersectionDetails/IntersectionDetails.css
@@ -3,6 +3,16 @@ aside#intersection-details {
   background-color: #fff;
   overflow-y: scroll;
   font-size: 0.85rem;
+  /* 
+   * Take this element out of the flex 
+   * flow on mobile, to avoid the issue
+   * with Chrome Android's seemingly broken
+   * Flex behavior
+   */
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 22vh;
 }
 
 .intersection-details {
@@ -64,6 +74,14 @@ aside#intersection-details {
   aside#intersection-details {
     flex: 0 0 330px;
     font-size: 1rem;
+
+    /**
+     * Restore proper flex behavior on normal displays
+     */
+    position: relative;
+    bottom: auto;
+    width: auto;
+    height: auto;
   }
   .intersection-details {
     padding: 1.25em;

--- a/src/pages/MapPage/MapPage.css
+++ b/src/pages/MapPage/MapPage.css
@@ -6,10 +6,17 @@ aside#map-control {
 main#map {
   position: relative;
   flex-grow: 1;
+
+  /** mobile only **/
+  margin-bottom: 22vh;
 }
 
 /* medium-sized displays and larger */
 @media (min-width: 640px) {
+  main#map {
+    margin-bottom: 0;
+  }
+
   aside#map-control {
     flex: 0 0 330px;
     padding: 20px 10px;


### PR DESCRIPTION
## In this PR

This PR attempts a workaround to prevent the intersections panel to grow/shrink when selecting a new place on mobile. I couldn't identify the root cause for this problem. It looks as if the mobile device doesn't properly adhere to the `flex: 0 0 27%` rule, which should lead to constant height.

The problem is not reproducible on the emulator, only the physical device. This PR takes the intersections panel out of the flex flow altogether, and applies an absolute position and height.