### PR TITLE
61 docs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,7 +29,17 @@
     "jsdoc/multiline-blocks": 1,
     "jsdoc/newline-after-description": 1,
     "jsdoc/no-multi-asterisks": 1,
-    "jsdoc/require-jsdoc": 1,
+    "jsdoc/require-jsdoc": [
+      1,
+      {
+        "contexts": [
+          "ArrowFunctionExpression",
+          "FunctionDeclaration",
+          "FunctionExpression",
+          "MethodDefinition"
+        ]
+      }
+    ],
     "jsdoc/require-param": [
       "warn",
       { "unnamedRootBase": ["props", "args"], "checkDestructured": true }

--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -3,7 +3,12 @@ import { Header, ITSBStore } from './components';
 import Peripleo from '@peripleo/peripleo';
 
 /**
+ * The root component of the application, defining the components that wrap (or appear
+ * adjacent to) all subpage components.
+ * The Outlet component will be replaced by subpage components as defined by
+ * React Router routes.
  *
+ * @returns {React.ReactElement} Root component of the application
  */
 export function Root() {
   const [authors, places, itineraries] = useLoaderData();

--- a/src/components/AuthorSelect/AuthorSelect.jsx
+++ b/src/components/AuthorSelect/AuthorSelect.jsx
@@ -3,6 +3,11 @@ import { useGraph, useSearch } from '@peripleo/peripleo';
 
 import './AuthorSelect.css';
 
+/**
+ * A React component for selecting and deselecting authors to show in map visualizations.
+ *
+ * @returns {React.ReactElemtn} A React functional component for selecting authors
+ */
 export const AuthorSelect = () => {
   const [mobileVisibility, setMobileVisibility] = useState(false);
 
@@ -12,6 +17,12 @@ export const AuthorSelect = () => {
 
   const selected = search.args.filters?.find((f) => f.name === 'authors')?.values || [];
 
+  /**
+   * Toggle an author selected or deselected by id.
+   *
+   * @param {string} id The author id to toggle.
+   * @returns {void}
+   */
   const toggleAuthor = (id) => () => {
     const updated = selected.includes(id) ? selected.filter((i) => i !== id) : [...selected, id];
 

--- a/src/components/AuthorSelect/AuthorSelect.jsx
+++ b/src/components/AuthorSelect/AuthorSelect.jsx
@@ -6,7 +6,7 @@ import './AuthorSelect.css';
 /**
  * A React component for selecting and deselecting authors to show in map visualizations.
  *
- * @returns {React.ReactElemtn} A React functional component for selecting authors
+ * @returns {React.ReactElement} A React functional component for selecting authors
  */
 export const AuthorSelect = () => {
   const [mobileVisibility, setMobileVisibility] = useState(false);

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -5,7 +5,7 @@ import './Header.css';
 /**
  * Header component, containing navigation links to pages in the application.
  *
- * @returns {ReactElement} Header React functional component
+ * @returns {React.ReactElement} Header React functional component
  */
 export function Header() {
   // hide mobile menu after navigating

--- a/src/components/ITSBStore/ITSBGraphProvider.jsx
+++ b/src/components/ITSBStore/ITSBGraphProvider.jsx
@@ -10,7 +10,7 @@ import { ITSBGraph } from './itsbGraph';
  *
  * The ITSBGraphProvider exposes the ITSB graph as global context.
  * @param {ITSBGraphProviderProps} props the component props
- * @returns {ReactElement} the React element
+ * @returns {React.ReactElement} the React element
  */
 export const ITSBGraphProvider = (props) => {
   const [graph, setGraph] = useState();

--- a/src/components/ITSBStore/ITSBSearchHandler.jsx
+++ b/src/components/ITSBStore/ITSBSearchHandler.jsx
@@ -3,13 +3,13 @@ import { SearchStatus, useGraph, useSearch } from '@peripleo/peripleo';
 
 /**
  * @typedef {object} ITSBSearchHandlerProps
- * @property {ReactElement} children child components
+ * @property {React.ReactElement} children child components
  *
  * The ITSBSearchHandler observes changes to the Peripleo search state,
  * and executes searchs (using the graph) if the search changes to
  * a PENDING state.
  * @param {ITSBSearchHandlerProps} props the component props
- * @returns {ReactElement} the React element
+ * @returns {React.ReactElement} the React element
  */
 export const ITSBSearchHandler = (props) => {
   const { search, setSearchState } = useSearch();

--- a/src/components/ITSBStore/ITSBStore.jsx
+++ b/src/components/ITSBStore/ITSBStore.jsx
@@ -3,7 +3,7 @@ import { ITSBGraphProvider } from './ITSBGraphProvider';
 
 /**
  * @typedef {object} ITSBStoreProps
- * @property {ReactElement} children child components
+ * @property {React.ReactElement} children child components
  *
  * The Store is a Peripleo-specific abstraction. It represents
  * the domain model of the application - in our case, a graph of
@@ -19,7 +19,7 @@ import { ITSBGraphProvider } from './ITSBGraphProvider';
  *   is completely specific to ITSB) and the Peripleo search interface
  *   (which has a predefined, generic structure).
  * @param {ITSBStoreProps} props the component props
- * @returns {ReactElement} the React element
+ * @returns {React.ReactElement} the React element
  */
 export const ITSBStore = (props) => {
   return (

--- a/src/components/ITSBStore/itsbGraph.js
+++ b/src/components/ITSBStore/itsbGraph.js
@@ -24,6 +24,7 @@ import {
  * - waypoints are (directionally!) linked to waypoints
  */
 export class ITSBGraph {
+  // eslint-disable-next-line jsdoc/require-jsdoc
   constructor() {
     this.graph = createGraph();
 
@@ -38,6 +39,11 @@ export class ITSBGraph {
       ],
 
       // Remove diacritics for search
+      /**
+       *
+       * @param obj
+       * @param path
+       */
       getFn: (obj, path) => {
         const value = Fuse.config.getFn(obj, path);
 
@@ -138,6 +144,7 @@ export class ITSBGraph {
    * The return value will be `true` if ALL IDs exist in the graph.
    *
    * @param {...string} arg one or multiple node ids
+   * @param {...any} args
    * @returns {boolean} true if ALL of the given IDs exist
    */
   exists = (...args) => {

--- a/src/components/ITSBStore/itsbGraph.test.js
+++ b/src/components/ITSBStore/itsbGraph.test.js
@@ -5,6 +5,7 @@ import authors from '../../../public/data/authors.json';
 import places from '../../../public/data/places.json';
 import itineraries from '../../../public/data/itineraries.json';
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 const initGraph = (authors, places, itineraries) => {
   const graph = new ITSBGraph();
   graph.init(authors, places, itineraries);

--- a/src/components/ITSBStore/utils/likelihoodUtils.js
+++ b/src/components/ITSBStore/utils/likelihoodUtils.js
@@ -50,9 +50,9 @@ import {
  *   'likelihood': ... // The inferred likelihood (type = number, value = 1, 2 or 3)
  * }
  *
- * @param {*} waypoint the Waypoint
- * @param {*} graph the ITSBGraph
- * @returns {*} the estimated interval
+ * @param {object} waypoint the Waypoint
+ * @param {ITSBGraph} graph the ITSBGraph
+ * @returns {object | void} the estimated interval, or undefined if not possible
  */
 export const estimateInterval = (waypoint, graph) => {
   if (!waypoint.when?.timespans) return;
@@ -74,12 +74,12 @@ export const estimateInterval = (waypoint, graph) => {
 };
 
 /**
- * Helper method infer the waypoint time interval, as outlined in the
+ * Helper method to infer the waypoint time interval, as outlined in the
  * documentation for `estimateInterval` (see above).
  *
- * @param {*} waypoint the Waypoint
- * @param {*} graph the ITSBGraph
- * @returns the inferred interval
+ * @param {object} waypoint the Waypoint
+ * @param {ITSBGraph} graph the ITSBGraph
+ * @returns {object | void} the inferred interval, or undefined if not possible
  */
 const inferInterval = (waypoint, graph) => {
   // Since this fn is internal, and only called from estimateTimeInterval,

--- a/src/components/ITSBStore/utils/waypointUtils.js
+++ b/src/components/ITSBStore/utils/waypointUtils.js
@@ -2,8 +2,8 @@
  * The method sorts waypoints according to the time
  * given in the `when` element.
  *
- * @param {Array<*>} waypoints the Waypoints (unsorted)
- * @returns {Array<*>} the Waypoints, sorted by time
+ * @param {Array<object>} waypoints the Waypoints (unsorted)
+ * @returns {Array<object>} the Waypoints, sorted by time
  */
 export const sortWaypointsByTime = (waypoints) => {
   const sorted = [...waypoints];
@@ -34,9 +34,9 @@ export const sortWaypointsByTime = (waypoints) => {
 /**
  * Sorts waypoints in the sequence represented in the graph.
  *
- * @param {Array<*>} waypoints the Waypoints
+ * @param {Array<object>} waypoints the Waypoints
  * @param {ITSBGraph} graph the ITSBGraph
- * @returns {Array<*>} the Waypoints, sorted by sequence
+ * @returns {Array<object>} the Waypoints, sorted by sequence
  */
 export const sortWaypointsBySequence = (waypoints, graph) => {
   const ids = new Set(waypoints.map((wp) => wp.id));
@@ -60,9 +60,12 @@ export const sortWaypointsBySequence = (waypoints, graph) => {
   });
 
   /**
+   * Traverse an itinerary in order from a starting waypoint by following links
+   * in the graph.
    *
-   * @param waypoint
-   * @param sorted
+   * @param {object} waypoint Starting waypoint
+   * @param {Array<object>} sorted Sorted waypoints so far
+   * @returns {Array<object>} Sorted waypoints
    */
   const traverseItinerary = (waypoint, sorted = [waypoint]) => {
     let nextNode;
@@ -93,7 +96,7 @@ export const sortWaypointsBySequence = (waypoints, graph) => {
  * - If the timespan has ONLY a start OR end date, the method returns true
  *   if the defined start or end date is inside the given date range.
  *
- * @param {*} timespan the timespan, in LinkedPlaces 'when' format
+ * @param {object} timespan the timespan, in LinkedPlaces 'when' format
  * @param {[string, string]} dateRange the date range, ISO-formatted start and end
  * @returns {boolean} true if the timespan is in the given date range
  */
@@ -117,9 +120,9 @@ const isTimespanInRange = (timespan, dateRange) => {
  * Filters the list of waypoints by the given date range, using the
  * method `isTimespanInRange` above.
  *
- * @param {Array<*>} waypoints the Waypoints
+ * @param {Array<object>} waypoints the Waypoints
  * @param {[string, string]} dateRange the date range
- * @returns {Array<*>} the list of Waypoints inside the given time interval
+ * @returns {Array<object>} the list of Waypoints inside the given time interval
  */
 export const filterWaypointsByTime = (waypoints, dateRange) => {
   return waypoints.filter((waypoint) =>
@@ -137,7 +140,7 @@ export const filterWaypointsByTime = (waypoints, dateRange) => {
  * In this case, the method will return the value for this specific qualifier
  * if it exists, or undefined otherwise.
  *
- * @param {*} waypoint the Waypoint
+ * @param {object} waypoint the Waypoint
  * @param {string} qualifier an optional qualifier
  * @returns {string | null} the start date, or null
  */
@@ -164,14 +167,14 @@ export const getWaypointStartValue = (waypoint, qualifier = null) => {
  * In this case, the method will return the value for this specific qualifier
  * if it exists, or undefined otherwise.
  *
- * @param {*} waypoint the Waypoint
+ * @param {object} waypoint the Waypoint
  * @param {string} qualifier an optional qualifier
- * @returns {string} the end date, or undefined
+ * @returns {string | null} the end date, or undefined
  */
 export const getWaypointEndValue = (waypoint, qualifier = null) => {
-  if (!waypoint.when?.timespans) return;
+  if (!waypoint.when?.timespans) return null;
 
-  if (waypoint.when.timespans.length === 0) return;
+  if (waypoint.when.timespans.length === 0) return null;
 
   const endSpan = waypoint.when.timespans.find((t) => t.end)?.end;
 
@@ -186,7 +189,7 @@ export const getWaypointEndValue = (waypoint, qualifier = null) => {
  * Returns the start of this waypoint as a Date object. Note that this
  * method will return undefined if the waypoint has no start specified.
  *
- * @param {*} waypoint the Waypoint
+ * @param {object} waypoint the Waypoint
  * @returns {Date} the start date, or undefined
  */
 export const getWaypointStartDate = (waypoint) => {
@@ -198,7 +201,7 @@ export const getWaypointStartDate = (waypoint) => {
  * Returns the end date of this waypoint as a Date object. Note that this
  * method will return undefined, if the waypoint has no end specified.
  *
- * @param {*} waypoint
+ * @param {object} waypoint A waypoint
  * @returns {Date} the end date, or undefined
  */
 export const getWaypointEndDate = (waypoint) => {
@@ -216,8 +219,8 @@ export const getWaypointEndDate = (waypoint) => {
  *
  * The method returns undefined if the waypoint has neither start nor end.
  *
- * @param {*} waypoint the Waypoint
- * @returns {[Date, Date]} a valid start/end interval or undefined
+ * @param {object} waypoint the Waypoint
+ * @returns {Array<Date> | void} a valid start/end interval or undefined
  */
 export const getWaypointInterval = (waypoint) => {
   const start = getWaypointStartDate(waypoint);
@@ -235,8 +238,8 @@ export const getWaypointInterval = (waypoint) => {
  * Returns a formatted string representation of the time
  * interval of this waypoint.
  *
- * @param {*} waypoint the Waypoint
- * @returns {string} formatted string representation
+ * @param {object} waypoint the Waypoint
+ * @returns {string | void} formatted string representation
  */
 export const formatInterval = (waypoint) => {
   const startVal = getWaypointStartValue(waypoint);

--- a/src/components/ITSBStore/utils/waypointUtils.js
+++ b/src/components/ITSBStore/utils/waypointUtils.js
@@ -35,7 +35,7 @@ export const sortWaypointsByTime = (waypoints) => {
  * Sorts waypoints in the sequence represented in the graph.
  *
  * @param {Array<*>} waypoints the Waypoints
- * @param {*} graph the ITSBGraph
+ * @param {ITSBGraph} graph the ITSBGraph
  * @returns {Array<*>} the Waypoints, sorted by sequence
  */
 export const sortWaypointsBySequence = (waypoints, graph) => {
@@ -59,6 +59,11 @@ export const sortWaypointsBySequence = (waypoints, graph) => {
     return !previous || !ids.has(previous);
   });
 
+  /**
+   *
+   * @param waypoint
+   * @param sorted
+   */
   const traverseItinerary = (waypoint, sorted = [waypoint]) => {
     let nextNode;
 
@@ -105,6 +110,7 @@ const isTimespanInRange = (timespan, dateRange) => {
     const date = new Date(timespan.end.latest || timespan.end.in);
     return date >= new Date(startDate) && date <= new Date(endDate);
   }
+  return false;
 };
 
 /**
@@ -133,12 +139,12 @@ export const filterWaypointsByTime = (waypoints, dateRange) => {
  *
  * @param {*} waypoint the Waypoint
  * @param {string} qualifier an optional qualifier
- * @returns {string} the start date, or undefined
+ * @returns {string | null} the start date, or null
  */
 export const getWaypointStartValue = (waypoint, qualifier = null) => {
-  if (!waypoint.when?.timespans) return;
+  if (!waypoint.when?.timespans) return null;
 
-  if (waypoint.when.timespans.length === 0) return;
+  if (waypoint.when.timespans.length === 0) return null;
 
   const startSpan = waypoint.when.timespans.find((t) => t.start)?.start;
   return startSpan

--- a/src/components/ITSBTooltip/ITSBTooltip.js
+++ b/src/components/ITSBTooltip/ITSBTooltip.js
@@ -4,11 +4,11 @@ import { formatInterval, groupBy, sortWaypointsByTime, waypointsAtPlace } from '
  * Generate tooltip markup for a waypoint in an itinerary, or a place with
  * intersecitons.
  *
- * @param {*} props Arguments object to destructure
- * @param {*} props.graph The ITSB graph context provider
- * @param {*} props.object The currently selected waypoint
- * @param {*} props.search The ITSB search context provider
- * @returns {string|undefined} The tooltip text, if possible
+ * @param {object} props Arguments object to destructure
+ * @param {ITSBGraph} props.graph The ITSB graph context provider
+ * @param {object} props.object The currently selected waypoint
+ * @param {SearchState} props.search The ITSB search context provider
+ * @returns {string | object | void} The tooltip text, if possible
  */
 export function ITSBTooltip({ graph, object, search }) {
   if (object?.present) {

--- a/src/components/IntersectionDetails/IntersectionDetails.jsx
+++ b/src/components/IntersectionDetails/IntersectionDetails.jsx
@@ -30,6 +30,12 @@ export const IntersectionDetails = (props) => {
   // Get all waypoints on this place, sort them by time
   const sorted = sortWaypointsByTime(waypointsAtPlace(itineraries, at?.id));
 
+  /**
+   * Helper method to get the likelihood of presence for a waypoint.
+   *
+   * @param {object} waypoint A waypoint
+   * @returns {number} Likelihood as a number between 1 and 3
+   */
   const getLikelihood = (waypoint) => estimateInterval(waypoint, graph)?.likelihood;
 
   return (

--- a/src/components/IntersectionDetails/IntersectionDetails.jsx
+++ b/src/components/IntersectionDetails/IntersectionDetails.jsx
@@ -15,7 +15,7 @@ import './IntersectionDetails.css';
  * IntersectionDetails renders waypoint descriptions, to accompany the map.
  * We are using this component in the sidebar of the "Intersections" page.
  * @param {IntersectionDetailProps} props the component props
- * @returns {ReactElement} the React element
+ * @returns {React.ReactElement} the React element
  */
 export const IntersectionDetails = (props) => {
   const { at } = props;

--- a/src/components/IntersectionsLayer/IntersectionsLayer.js
+++ b/src/components/IntersectionsLayer/IntersectionsLayer.js
@@ -4,6 +4,14 @@ import { Presence } from './presence';
 
 export const intersectionsScale = scaleLinear().domain([0, 10]).range([6, 36]);
 
+/**
+ * Convert a Presence object into a list of intersections: places (with more than
+ * one presence) and their associated author presences and likelihoods.
+ *
+ * @param {Presence} p A Presence object
+ * @param {ITSBGraph} graph The ITSB graph
+ * @returns {Array<object>} An array of intersections
+ */
 const toMapData = (p, graph) => {
   const { presence } = p;
 
@@ -38,6 +46,13 @@ const toMapData = (p, graph) => {
   return data.filter((p) => Object.keys(p.present).length > 0);
 };
 
+/**
+ * Get the number of people present at a given level of certainty (likelihood).
+ *
+ * @param {object} place A place object
+ * @param {number} likelihood Certainty score from 1 to 3
+ * @returns {number} Number of people present at that certainty level
+ */
 const countPresent = (place, likelihood) => {
   let count = 0;
 
@@ -48,6 +63,14 @@ const countPresent = (place, likelihood) => {
   return count;
 };
 
+/**
+ * Renders three Deck.GL Scatterplot layers, one for each level of certainty, based on
+ * presences of authors in the same place in the same timespan.
+ *
+ * @param {object} props destructured props parameter
+ * @param {object} props.selected the currently selected place (GeoJSON)
+ * @returns {Function} A curried function returning Deck.GL scatterplot layers
+ */
 export const IntersectionsLayer =
   ({ selected }) =>
   (itineraries, graph) => {
@@ -67,7 +90,18 @@ export const IntersectionsLayer =
           filled: true,
           radiusUnits: 'pixels',
           lineWidthUnits: 'pixels',
+
+          // eslint-disable-next-line jsdoc/require-jsdoc
           getPosition: (d) => d.geometry.coordinates,
+
+          /**
+           * Get the radius for a point on the map based on number of presences
+           * for this likelihood. The smallest circle will be the most likely,
+           * and outer rings are wider for increasingly unlikely presences.
+           *
+           * @param {object} d A place in the list of intersections
+           * @returns {number} The radius of the circle
+           */
           getRadius: (d) => {
             // center circle = likelihood of 3
             let count = countPresent(d, 3);
@@ -85,6 +119,15 @@ export const IntersectionsLayer =
             return intersectionsScale(count);
           },
 
+          /**
+           * Get the fill color for a point on the map based on number of presences
+           * for this likelihood. The most likely points will be the most opaque,
+           * and outer rings are more transparent for increasingly unlikely presences.
+           *
+           * @param {object} g A place on the intersections map
+           * @returns {Array<number>} An array of 4 numbers in the format [r,g,b,a] with values
+           * from 0 to 255 for each
+           */
           getFillColor: (g) => {
             // lower opacity for lower likelihood
             let opacity = 255;
@@ -95,9 +138,18 @@ export const IntersectionsLayer =
               opacity = 0.25 * 255;
             }
 
+            // blue for selected, orange for not selected
             return selected?.id === g.id ? [65, 105, 225, opacity] : [252, 176, 64, opacity];
           },
 
+          /**
+           * Get the outline color for a point on the map: blue if selected, orange if
+           * not selected.
+           *
+           * @param {object} g A place on the intersections map
+           * @returns {Array<number>} An array of 4 numbers in the format [r,g,b,a] with values
+           * from 0 to 255 for each
+           */
           getLineColor: (g) => (selected?.id === g.id ? [0, 0, 0, 144] : [200, 100, 0, 144]),
         })
     );

--- a/src/components/IntersectionsLayer/presence.js
+++ b/src/components/IntersectionsLayer/presence.js
@@ -25,6 +25,12 @@ import { estimateInterval } from '../ITSBStore';
  * }
  */
 export class Presence {
+  /**
+   * Create a new Presence instance.
+   *
+   * @param {Array<object>} itineraries A list of itineraries (author and waypoints)
+   * @param {ITSBGraph} graph The ITSB graph
+   */
   constructor(itineraries, graph) {
     this.graph = graph;
 
@@ -37,7 +43,7 @@ export class Presence {
    * Adds one itinerary to this Presence object.
    *
    * @param {string} author the author ID
-   * @param {*} waypoints the itinerary Waypoints
+   * @param {Array<object>} waypoints the itinerary Waypoints
    */
   addOneItinerary = (author, waypoints) => {
     // Get months and likelihoods for this author

--- a/src/components/IntersectionsLegend/IntersectionsLegend.jsx
+++ b/src/components/IntersectionsLegend/IntersectionsLegend.jsx
@@ -2,14 +2,16 @@ import { BsInfoLg, BsX } from 'react-icons/bs';
 import './IntersectionsLegend.css';
 
 /**
- * A legend for the intersections visualization, adapted from the original ITSB project.
+ * @typedef {object} IntersectionsLegendProps
+ * @property {Function} onClick Event handler to toggle the legend expanded/collapsed
+ * @property {boolean} visible Visible state boolean for the legend
  *
- * @param {React.ComponentProps} props React component props
- * @param {Function} props.onClick Event handler to toggle the legend expanded/collapsed
- * @param {boolean} props.visible Visible state boolean for the legend
+ * A legend for the intersections visualization, adapted from the original ITSB project.
+ * @param {IntersectionsLegendProps} props React component props
  * @returns {React.ReactElement} Legend React functional component
  */
-export function IntersectionsLegend({ onClick, visible }) {
+export function IntersectionsLegend(props) {
+  const { onClick, visible } = props;
   return (
     <>
       <legend id="intersection-legend" className={visible ? 'visible' : 'hidden'}>

--- a/src/components/ItinerariesLayer/ItinerariesLayer.js
+++ b/src/components/ItinerariesLayer/ItinerariesLayer.js
@@ -3,6 +3,17 @@ import { ArcLayer, GeoJsonLayer } from '@peripleo/peripleo/deck.gl';
 const POINT_MIN_RADIUS = 6;
 const POINT_MAX_RADIUS = 22;
 
+/**
+ * @typedef {object} Arc
+ * @property {object} from GeoJSON geometry for the start point
+ * @property {object} to GeoJSON geometry for the end point
+ *
+ * Compute arcs for the itineraries/trajectories view, in a format readable by
+ * Deck.GL's ArcLayer.
+ * @param {Array<object>} waypoints An ordered list of waypoints to translate into arcs
+ * @param {ITSBGraph} graph The ITSB graph
+ * @returns {Array<Arc>} A list of Arcs (objects with "from" and "to" geometries)
+ */
 const toArc = (waypoints, graph) => {
   const trajectory = [];
 
@@ -88,6 +99,13 @@ export const ItinerariesLayer = () => (resultItems, graph) => {
       lineWidthUnits: 'pixels',
       getLineColor: [252, 176, 64, 220],
       getFillColor: [252, 176, 64, 180],
+      /**
+       * Scale the radius of a given point in the underlying GeoJSON layer
+       * by the number of waypoints at that place.
+       *
+       * @param {object} d A place in the trajectories visualization
+       * @returns {number} Radius of the place's point
+       */
       getPointRadius: (d) => {
         const { wpCount } = d.properties;
         return k * (wpCount - 1) + POINT_MIN_RADIUS;
@@ -99,6 +117,7 @@ export const ItinerariesLayer = () => (resultItems, graph) => {
     ...resultItems.map(({ author, waypoints }) => {
       const arc = toArc(waypoints, graph);
 
+      // Use the author color set in the Python convertJSON script
       const { color } = graph.getNode(author);
 
       return new ArcLayer({
@@ -110,7 +129,9 @@ export const ItinerariesLayer = () => (resultItems, graph) => {
         getHeight: 1,
         getTilt: 10,
         greatCircle: false,
+        // eslint-disable-next-line jsdoc/require-jsdoc
         getSourcePosition: (d) => d.from.coordinates,
+        // eslint-disable-next-line jsdoc/require-jsdoc
         getTargetPosition: (d) => d.to.coordinates,
         getSourceColor: color,
         getTargetColor: color,

--- a/src/components/MonthRangeInput/MonthRangeInput.css
+++ b/src/components/MonthRangeInput/MonthRangeInput.css
@@ -51,7 +51,6 @@ input[type='month'] {
   width: 120px;
   text-align: center;
   font-size: 0.75rem;
-  font-family: Courier, monospace;
   line-height: 30px;
   border: 1px solid gray;
   border-radius: 2px;

--- a/src/components/MonthRangeInput/MonthRangeInput.jsx
+++ b/src/components/MonthRangeInput/MonthRangeInput.jsx
@@ -13,12 +13,46 @@ import { useSearch } from '@peripleo/peripleo';
 import './MonthRangeInput.css';
 import { useInterval } from './useInterval';
 
-// Utility string and helper functions
 const fmtString = 'yyyy-MM';
+/**
+ * Format a date according to the above format (YYYY-MM).
+ *
+ * @param {Date} date A JavaScript Date object
+ * @returns {string} The formatted date
+ */
 const fmt = (date) => format(date, fmtString);
+
+/**
+ * Get the first day of the month for a given month.
+ *
+ * @param {string} formattedDate A month formatted as YYYY-MM
+ * @returns {Date} The first day of the month as a JavaScript Date object
+ */
 const monthStart = (formattedDate) => startOfMonth(new Date(`${formattedDate}-02T00:00:00`));
+
+/**
+ * Get the last day of the month for a given month.
+ *
+ * @param {string} formattedDate A month formatted as YYYY-MM
+ * @returns {Date} The last day of the month as a JavaScript Date object
+ */
 const monthEnd = (formattedDate) => endOfMonth(new Date(`${formattedDate}-02T00:00:00`));
+
+/**
+ * Check if a given string is a valid date according to the format YYYY-MM.
+ *
+ * @param {string} date A date formatted as a string
+ * @returns {boolean} True if valid, false if invalid
+ */
 const isValid = (date) => date.length === fmtString.length && isMatch(date, fmtString);
+
+/**
+ * Check if a range of two dates is valid, i.e. the first month is before the second month.
+ *
+ * @param {Date} from The earlier date to compare
+ * @param {Date} to The later date to compare
+ * @returns {boolean} True if the earlier date is before the later date, false if not
+ */
 const isRangeValid = (from, to) => isBefore(monthStart(from), monthEnd(to));
 
 // TODO lookup min date from graph!

--- a/src/components/MonthRangeInput/MonthRangeInput.jsx
+++ b/src/components/MonthRangeInput/MonthRangeInput.jsx
@@ -28,7 +28,7 @@ const maxDate = fmt(endOfToday());
 /**
  * Month range input controls for filtering the map visualizations.
  *
- * @returns {ReactElement} Functional component for date filter controls
+ * @returns {React.ReactElement} Functional component for date filter controls
  */
 export function MonthRangeInput() {
   const { search, setFilter } = useSearch();

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,8 +6,19 @@ import { Root } from './Root';
 
 import './index.css';
 
+/**
+ * Utility function to GET data formatted as JSON from a passed URL.
+ *
+ * @param {string} url The URL to fetch
+ * @returns {object} The returned JSON as a javascript object
+ */
 const fetchData = (url) => fetch(url).then((res) => res.json());
 
+/**
+ * Async Promise-based function to load all data required for the map and search pages.
+ *
+ * @returns {Array<object>} Asynchronously fetched array of objects with map/search data.
+ */
 const fetchMapData = async () =>
   await Promise.all([
     fetchData('data/authors.json'),

--- a/src/pages/CreditsPage/CreditsPage.jsx
+++ b/src/pages/CreditsPage/CreditsPage.jsx
@@ -3,7 +3,7 @@ import './CreditsPage.css';
 /**
  * Credits page for ITSB (static content)
  *
- * @returns {ReactElement} Credits page React functional component
+ * @returns {React.ReactElement} Credits page React functional component
  */
 export function CreditsPage() {
   return (

--- a/src/pages/ErrorPage/ErrorPage.jsx
+++ b/src/pages/ErrorPage/ErrorPage.jsx
@@ -5,7 +5,7 @@ import { useRouteError } from 'react-router-dom';
  * Error page using React Router to handle known errors, with static defaults.
  * Will not render in <Outlet> so requires its own Header.
  *
- * @returns {ReactElement} Error page React functional component
+ * @returns {React.ReactElement} Error page React functional component
  */
 export function ErrorPage() {
   const error = useRouteError();

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -4,7 +4,7 @@ import './HomePage.css';
 /**
  * Home page for ITSB (static content)
  *
- * @returns {ReactElement} Home page React functional component
+ * @returns {React.ReactElement} Home page React functional component
  */
 export function HomePage() {
   return (

--- a/src/pages/InstructionsPage/InstructionsPage.jsx
+++ b/src/pages/InstructionsPage/InstructionsPage.jsx
@@ -3,7 +3,7 @@ import './InstructionsPage.css';
 /**
  * Instructions page for ITSB (static content)
  *
- * @returns {ReactElement} Instructions page React functional component
+ * @returns {React.ReactElement} Instructions page React functional component
  */
 export function InstructionsPage() {
   return (

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -15,7 +15,7 @@ import './MapPage.css';
 /**
  * The page component for the map visualizations.
  *
- * @returns {ReactElement} React map functional component
+ * @returns {React.ReactElement} React map functional component
  */
 export function MapPage() {
   const { loaded } = useOutletContext();

--- a/src/pages/MapPage/MapPage.jsx
+++ b/src/pages/MapPage/MapPage.jsx
@@ -20,8 +20,13 @@ import './MapPage.css';
 export function MapPage() {
   const { loaded } = useOutletContext();
 
+  // if there is no entry in localStorage, show legend by default; otherwise hide
   const storedHidden = localStorage.getItem('itsb-legend');
   const [legendVisible, setLegendVisible] = useState(!storedHidden);
+  /**
+   * Set the react state to show or hide the legend. In addition, if there is
+   * no entry in localStorage for the legend, create one.
+   */
   const toggleLegend = () => {
     setLegendVisible((prev) => !prev);
     if (!storedHidden) {
@@ -35,6 +40,13 @@ export function MapPage() {
     ? ItinerariesLayer()
     : IntersectionsLayer({ selected: selectedIntersection });
 
+  /**
+   * Event handler for clicking a city on the map
+   *
+   * @param {object} props destructured props parameter
+   * @param {object} props.object The clicked city on the map
+   * @returns {void}
+   */
   const onClick = ({ object }) => setSelectedIntersection(object);
 
   return (

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -20,6 +20,11 @@ export function SearchPage() {
 
   const [results, setResults] = useState([]);
 
+  /**
+   * Event handler for the search field text box.
+   *
+   * @param {ChangeEvent} evt Event triggered by a change in the search field
+   */
   const onChange = (evt) => {
     const { value } = evt.target;
 

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -11,7 +11,7 @@ import './SearchPage.css';
 /**
  * Search page for ITSB, using Peripleo search and filtering.
  *
- * @returns {ReactElement} Search page React functional component
+ * @returns {React.ReactElement} Search page React functional component
  */
 export function SearchPage() {
   const { loaded } = useOutletContext();

--- a/src/pages/SearchPage/SearchResult.jsx
+++ b/src/pages/SearchPage/SearchResult.jsx
@@ -3,7 +3,7 @@ import { formatInterval } from '../../components/ITSBStore/utils';
 /**
  * @typedef {object} SearchResultProps
  * @property {object} data the search result data
- * @property {object} graph the ITSB graph
+ * @property {ITSBGraph} graph the ITSB graph
  *
  * A single search result in the the search results list.
  * @param {SearchResultProps} props the component props

--- a/src/pages/SearchPage/SearchResult.jsx
+++ b/src/pages/SearchPage/SearchResult.jsx
@@ -7,7 +7,7 @@ import { formatInterval } from '../../components/ITSBStore/utils';
  *
  * A single search result in the the search results list.
  * @param {SearchResultProps} props the component props
- * @returns {ReactElement} the React element
+ * @returns {React.ReactElement} the React element
  */
 export const SearchResult = (props) => {
   const { data, graph } = props;


### PR DESCRIPTION
## In this PR

Per #61:
- Document remaining undocumented functions, including arrow functions
- Scope all `ReactElement` to `React.ReactElement`
- Change `*` param types to `object` where appropriate
- Add `@typedef` where missing for React props